### PR TITLE
Revise `mmc-get-drive-cap` to use the MMC/SCSCI `INQUIRY` command.

### DIFF
--- a/include/cdio++/mmc.hpp
+++ b/include/cdio++/mmc.hpp
@@ -100,7 +100,7 @@ cdio_mmc_level_t mmcGetDriveMmcCap()
 */
 cdio_mmc_inquiry_version_t mmcGetInquiryDriveMmcCap()
 {
-  return mmc_get_drive_mmc_cap_from_inquiry_version(p_cdio);
+  return mmc_get_INQUIRY_version(p_cdio);
 }
 
 /**

--- a/include/cdio++/mmc.hpp
+++ b/include/cdio++/mmc.hpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2005, 2006, 2008, 2010 Rocky Bernstein <rocky@gnu.org>
+    Copyright (C) 2005, 2006, 2008, 2010, 2026 Rocky Bernstein <rocky@gnu.org>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/** 
+/**
  * \file mmc.hpp
  *  \brief methods relating to  MMC (Multimedia Commands). This file
  *  should not be #included directly.
@@ -23,14 +23,14 @@
 
 /**
   Read Audio Subchannel information
-  
+
   @param p_cdio the CD object to be acted upon.
   @param p_subchannel place for returned subchannel information
 
   A DriverOpException is raised on error.
 */
 void
-mmcAudioReadSubchannel (/*out*/ cdio_subchannel_t *p_subchannel) 
+mmcAudioReadSubchannel (/*out*/ cdio_subchannel_t *p_subchannel)
 {
   driver_return_code_t drc = mmc_audio_read_subchannel (p_cdio, p_subchannel);
   possible_throw_device_exception(drc);
@@ -43,18 +43,18 @@ mmcAudioReadSubchannel (/*out*/ cdio_subchannel_t *p_subchannel)
 
   A DriverOpException is raised on error.
 */
-void mmcEjectMedia() 
+void mmcEjectMedia()
 {
   driver_return_code_t drc = mmc_eject_media( p_cdio );
   possible_throw_device_exception(drc);
 }
-  
+
 /**
   Get the lsn of the end of the CD
-  
+
   @return the lsn. On error return CDIO_INVALID_LSN.
 */
-lsn_t mmcGetDiscLastLsn() 
+lsn_t mmcGetDiscLastLsn()
 {
   return mmc_get_disc_last_lsn( p_cdio );
 }
@@ -62,13 +62,13 @@ lsn_t mmcGetDiscLastLsn()
 /**
   Return the discmode as reported by the MMC Read (FULL) TOC
   command.
-  
+
   Information was obtained from Section 5.1.13 (Read TOC/PMA/ATIP)
   pages 56-62 from the MMC draft specification, revision 10a
   at http://www.t10.org/ftp/t10/drafts/mmc/mmc-r10a.pdf See
   especially tables 72, 73 and 75.
 */
-discmode_t mmcGetDiscmode() 
+discmode_t mmcGetDiscmode()
 {
   return mmc_get_discmode( p_cdio );
 }
@@ -79,36 +79,47 @@ discmode_t mmcGetDiscmode()
 */
 void mmcGetDriveCap ( /*out*/ cdio_drive_read_cap_t  *p_read_cap,
                       /*out*/ cdio_drive_write_cap_t *p_write_cap,
-                      /*out*/ cdio_drive_misc_cap_t  *p_misc_cap) 
+                      /*out*/ cdio_drive_misc_cap_t  *p_misc_cap)
 {
   mmc_get_drive_cap ( p_cdio, p_read_cap, p_write_cap, p_misc_cap);
 }
 
 /**
-  Get the MMC level supported by the device.
+  Get the MMC level supported by the device. (old)
+
+  \deprecated This enum is deprecated and will be removed in the next major
+release. Please use mmcGetInquiryDriveMmcCap() instead.
 */
-cdio_mmc_level_t mmcGetDriveMmcCap() 
+cdio_mmc_level_t mmcGetDriveMmcCap()
 {
   return mmc_get_drive_mmc_cap(p_cdio);
 }
 
 /**
+  Get the MMC level supported by the device.
+*/
+cdio_mmc_inquiry_version_t mmcGetInquiryDriveMmcCap()
+{
+  return mmc_get_drive_mmc_cap_from_inquiry_version(p_cdio);
+}
+
+/**
   Get the DVD type associated with cd object.
-  
+
   @return the DVD discmode.
 */
-discmode_t mmcGetDvdStructPhysical (cdio_dvd_struct_t *s) 
+discmode_t mmcGetDvdStructPhysical (cdio_dvd_struct_t *s)
 {
   return mmc_get_dvd_struct_physical (p_cdio, s);
 }
 
 /**
   Get the CD-ROM hardware info via an MMC INQUIRY command.
-  
+
   @return true if we were able to get hardware info, false if we had
   an error.
 */
-bool mmcGetHwinfo ( /* out*/ cdio_hwinfo_t *p_hw_info ) 
+bool mmcGetHwinfo ( /* out*/ cdio_hwinfo_t *p_hw_info )
 {
   return mmc_get_hwinfo ( p_cdio, p_hw_info );
 }
@@ -119,22 +130,22 @@ bool mmcGetHwinfo ( /* out*/ cdio_hwinfo_t *p_hw_info )
   @return 1 if media has changed since last call, 0 if not. Error
   return codes are the same as driver_return_code_t
 */
-int mmcGetMediaChanged() 
+int mmcGetMediaChanged()
 {
   return mmc_get_media_changed(p_cdio);
 }
 
 /**
   Get the media catalog number (MCN) from the CD via MMC.
-  
+
   @return the media catalog number r NULL if there is none or we
   don't have the ability to get it.
-  
+
   Note: The caller must free the returned string with cdio_free()
   when done with it.
-  
+
 */
-char * mmcGetMcn () 
+char * mmcGetMcn ()
 {
   return mmc_get_mcn ( p_cdio );
 }
@@ -146,7 +157,7 @@ char * mmcGetMcn ()
 
     A DriverOpException is raised on error.
 */
-void mmcAudioGetVolume (mmc_audio_volume_t *p_volume) 
+void mmcAudioGetVolume (mmc_audio_volume_t *p_volume)
 {
   driver_return_code_t drc = mmc_audio_get_volume (p_cdio, p_volume);
   possible_throw_device_exception(drc);
@@ -154,59 +165,59 @@ void mmcAudioGetVolume (mmc_audio_volume_t *p_volume)
 
 /**
   Report if CD-ROM has a praticular kind of interface (ATAPI, SCSCI, ...)
-  Is it possible for an interface to have serveral? If not this 
+  Is it possible for an interface to have serveral? If not this
   routine could probably return the single mmc_feature_interface_t.
   @return true if we have the interface and false if not.
 */
-bool_3way_t mmcHaveInterface( cdio_mmc_feature_interface_t e_interface ) 
+bool_3way_t mmcHaveInterface( cdio_mmc_feature_interface_t e_interface )
 {
   return mmc_have_interface( p_cdio, e_interface );
 }
 
 /**
-   Run a MODE_SENSE command (6- or 10-byte version) 
-   and put the results in p_buf 
+   Run a MODE_SENSE command (6- or 10-byte version)
+   and put the results in p_buf
    @return DRIVER_OP_SUCCESS if we ran the command ok.
 */
-int mmcModeSense( /*out*/ void *p_buf, int i_size, int page) 
+int mmcModeSense( /*out*/ void *p_buf, int i_size, int page)
 {
   return mmc_mode_sense( p_cdio, /*out*/ p_buf, i_size, page);
 }
 
 /**
-    Run a MODE_SENSE command (10-byte version) 
-    and put the results in p_buf 
+    Run a MODE_SENSE command (10-byte version)
+    and put the results in p_buf
     @return DRIVER_OP_SUCCESS if we ran the command ok.
 */
-int mmcModeSense10( /*out*/ void *p_buf, int i_size, int page) 
+int mmcModeSense10( /*out*/ void *p_buf, int i_size, int page)
 {
   return mmc_mode_sense_10( p_cdio, /*out*/ p_buf, i_size, page);
 }
 
 /**
-    Run a MODE_SENSE command (6-byte version) 
-    and put the results in p_buf 
+    Run a MODE_SENSE command (6-byte version)
+    and put the results in p_buf
     @return DRIVER_OP_SUCCESS if we ran the command ok.
 */
-int mmcModeSense6( /*out*/ void *p_buf, int i_size, int page) 
+int mmcModeSense6( /*out*/ void *p_buf, int i_size, int page)
 {
   return mmc_mode_sense_6( p_cdio, /*out*/ p_buf, i_size, page);
 }
 
 /**
     Issue a MMC READ_CD command.
-  
-@param p_cdio  object to read from 
 
-@param p_buf   Place to store data. The caller should ensure that 
+@param p_cdio  object to read from
+
+@param p_buf   Place to store data. The caller should ensure that
                p_buf can hold at least i_blocksize * i_blocks  bytes.
 
-@param i_lsn   sector to read 
-  
+@param i_lsn   sector to read
+
 @param expected_sector_type restricts reading to a specific CD
   sector type.  Only 3 bits with values 1-5 are used:
     0 all sector types
-    1 CD-DA sectors only 
+    1 CD-DA sectors only
     2 Mode 1 sectors only
     3 Mode 2 formless sectors only. Note in contrast to all other
       values an MMC CD-ROM is not required to support this mode.
@@ -220,101 +231,101 @@ int mmcModeSense6( /*out*/ void *p_buf, int i_size, int page)
   modified by flaw obscuring mechanisms such as audio data mute and
   interpolate.  If the data being read is CD-DA and DAP is true,
   then the user data returned should be modified by flaw obscuring
-  mechanisms such as audio data mute and interpolate.  
-  
+  mechanisms such as audio data mute and interpolate.
+
   b_sync_header return the sync header (which will probably have
   the same value as CDIO_SECTOR_SYNC_HEADER of size
   CDIO_CD_SYNC_SIZE).
-  
+
   @param header_codes Header Codes refer to the sector header and
-  the sub-header that is present in mode 2 formed sectors: 
-  
-   0 No header information is returned.  
-   1 The 4-byte sector header of data sectors is be returned, 
+  the sub-header that is present in mode 2 formed sectors:
+
+   0 No header information is returned.
+   1 The 4-byte sector header of data sectors is be returned,
    2 The 8-byte sector sub-header of mode 2 formed sectors is
-     returned.  
-   3 Both sector header and sub-header (12 bytes) is returned.  
-   The Header preceeds the rest of the bytes (e.g. user-data bytes) 
+     returned.
+   3 Both sector header and sub-header (12 bytes) is returned.
+   The Header preceeds the rest of the bytes (e.g. user-data bytes)
    that might get returned.
-   
-   @param b_user_data  Return user data if true. 
-   
+
+   @param b_user_data  Return user data if true.
+
    For CD-DA, the User Data is CDIO_CD_FRAMESIZE_RAW bytes.
 
    For Mode 1, The User Data is ISO_BLOCKSIZE bytes beginning at
    offset CDIO_CD_HEADER_SIZE+CDIO_CD_SUBHEADER_SIZE.
-   
+
    For Mode 2 formless, The User Data is M2RAW_SECTOR_SIZE bytes
    beginning at offset CDIO_CD_HEADER_SIZE+CDIO_CD_SUBHEADER_SIZE.
-   
+
    For data Mode 2, form 1, User Data is ISO_BLOCKSIZE bytes beginning at
    offset CDIO_CD_XA_SYNC_HEADER.
-   
+
    For data Mode 2, form 2, User Data is 2 324 bytes beginning at
    offset CDIO_CD_XA_SYNC_HEADER.
-   
-   @param b_sync 
+
+   @param b_sync
 
    @param b_edc_ecc true if we return EDC/ECC error detection/correction bits.
-   
+
    The presence and size of EDC redundancy or ECC parity is defined
-   according to sector type: 
-   
-   CD-DA sectors have neither EDC redundancy nor ECC parity.  
-   
+   according to sector type:
+
+   CD-DA sectors have neither EDC redundancy nor ECC parity.
+
    Data Mode 1 sectors have 288 bytes of EDC redundancy, Pad, and
    ECC parity beginning at offset 2064.
-   
+
    Data Mode 2 formless sectors have neither EDC redundancy nor ECC
    parity
-   
+
    Data Mode 2 form 1 sectors have 280 bytes of EDC redundancy and
    ECC parity beginning at offset 2072
-   
+
    Data Mode 2 form 2 sectors optionally have 4 bytes of EDC
    redundancy beginning at offset 2348.
-   
-   
+
+
    @param c2_error_information If true associate a bit with each
    sector for C2 error The resulting bit field is ordered exactly as
    the main channel bytes.  Each 8-bit boundary defines a byte of
    flag bits.
-   
+
    @param subchannel_selection subchannel-selection bits
-   
+
      0  No Sub-channel data shall be returned.  (0 bytes)
      1  RAW P-W Sub-channel data shall be returned.  (96 byte)
      2  Formatted Q sub-channel data shall be transferred (16 bytes)
-     3  Reserved     
+     3  Reserved
      4  Corrected and de-interleaved R-W sub-channel (96 bytes)
      5-7  Reserved
 
    @param i_blocksize size of the a block expected to be returned
-     
+
    @param i_blocks number of blocks expected to be returned.
 
-   A DriverOpException is raised on error.     
+   A DriverOpException is raised on error.
   */
-void 
-mmcReadCd ( void *p_buf, lsn_t i_lsn, int expected_sector_type, 
-            bool b_digital_audio_play, bool b_sync, uint8_t header_codes, 
-            bool b_user_data, bool b_edc_ecc, uint8_t c2_error_information, 
-            uint8_t subchannel_selection, uint16_t i_blocksize, 
-            uint32_t i_blocks ) 
+void
+mmcReadCd ( void *p_buf, lsn_t i_lsn, int expected_sector_type,
+            bool b_digital_audio_play, bool b_sync, uint8_t header_codes,
+            bool b_user_data, bool b_edc_ecc, uint8_t c2_error_information,
+            uint8_t subchannel_selection, uint16_t i_blocksize,
+            uint32_t i_blocks )
 {
-  driver_return_code_t drc = 
-    mmc_read_cd ( p_cdio, p_buf, i_lsn, expected_sector_type, 
-                  b_digital_audio_play, b_sync, header_codes, 
-                  b_user_data, b_edc_ecc, c2_error_information, 
+  driver_return_code_t drc =
+    mmc_read_cd ( p_cdio, p_buf, i_lsn, expected_sector_type,
+                  b_digital_audio_play, b_sync, header_codes,
+                  b_user_data, b_edc_ecc, c2_error_information,
                   subchannel_selection, i_blocksize, i_blocks );
   possible_throw_device_exception(drc);
 }
 
 /**
 
-    Read just the user data part of some sort of data sector (via 
-    mmc_read_cd). 
-    
+    Read just the user data part of some sort of data sector (via
+    mmc_read_cd).
+
     @param p_cdio object to read from
 
     @param p_buf place to read data into.  The caller should make sure
@@ -331,9 +342,9 @@ mmcReadCd ( void *p_buf, lsn_t i_lsn, int expected_sector_type,
 
   */
 void mmcReadDataSectors ( void *p_buf, lsn_t i_lsn, uint16_t i_blocksize,
-                          uint32_t i_blocks=1) 
+                          uint32_t i_blocks=1)
 {
-  driver_return_code_t drc = mmc_read_data_sectors ( p_cdio, p_buf, i_lsn, 
+  driver_return_code_t drc = mmc_read_data_sectors ( p_cdio, p_buf, i_lsn,
                                                      i_blocksize, i_blocks );
   possible_throw_device_exception(drc);
 }
@@ -344,22 +355,22 @@ void mmcReadDataSectors ( void *p_buf, lsn_t i_lsn, uint16_t i_blocksize,
 
     A DriverOpException is raised on error.
  */
-void mmcReadSectors ( void *p_buf, lsn_t i_lsn,  int read_sector_type, 
-                      uint32_t i_blocks=1) 
+void mmcReadSectors ( void *p_buf, lsn_t i_lsn,  int read_sector_type,
+                      uint32_t i_blocks=1)
 {
-  driver_return_code_t drc = mmc_read_sectors ( p_cdio, p_buf, i_lsn, 
+  driver_return_code_t drc = mmc_read_sectors ( p_cdio, p_buf, i_lsn,
                                                 read_sector_type, i_blocks);
   possible_throw_device_exception(drc);
 }
 
 /**
-    Run an MMC command. 
-    
+    Run an MMC command.
+
     @param p_cdio	 CD structure set by cdio_open().
     @param i_timeout_ms  time in milliseconds we will wait for the command
-                         to complete. 
-    @param p_cdb	 CDB bytes. All values that are needed should be set 
-                         on input. We'll figure out what the right CDB length 
+                         to complete.
+    @param p_cdb	 CDB bytes. All values that are needed should be set
+                         on input. We'll figure out what the right CDB length
                          should be.
     @param e_direction   direction the transfer is to go.
     @param i_buf	 Size of buffer
@@ -368,7 +379,7 @@ void mmcReadSectors ( void *p_buf, lsn_t i_lsn,  int read_sector_type,
     @return 0 if command completed successfully.
   */
 int mmcRunCmd( unsigned int i_timeout_ms, const mmc_cdb_t *p_cdb,
-               cdio_mmc_direction_t e_direction, unsigned int i_buf, 
+               cdio_mmc_direction_t e_direction, unsigned int i_buf,
                /*in/out*/ void *p_buf )
 {
   return mmc_run_cmd( p_cdio, i_timeout_ms, p_cdb, e_direction, i_buf, p_buf );
@@ -381,7 +392,7 @@ int mmcRunCmd( unsigned int i_timeout_ms, const mmc_cdb_t *p_cdb,
 
   A DriverOpException is raised on error.
 */
-void mmcSetBlocksize ( uint16_t i_blocksize) 
+void mmcSetBlocksize ( uint16_t i_blocksize)
 {
   driver_return_code_t drc = mmc_set_blocksize ( p_cdio, i_blocksize);
   possible_throw_device_exception(drc);
@@ -389,7 +400,7 @@ void mmcSetBlocksize ( uint16_t i_blocksize)
 
 
 /**
-  Set the drive speed via MMC. 
+  Set the drive speed via MMC.
 
   @param i_speed speed to set drive to.
 
@@ -402,28 +413,28 @@ void mmcSetSpeed( int i_speed )
 }
 
 /**
-  Load or Unload media using a MMC START STOP command. 
-  
+  Load or Unload media using a MMC START STOP command.
+
   @param p_cdio  the CD object to be acted upon.
   @param b_eject eject if true and close tray if false
   @param b_immediate wait or don't wait for operation to complete
   @param power_condition Set CD-ROM to idle/standby/sleep. If nonzero
   eject/load is ignored, so set to 0 if you want to eject or load.
-  
+
   @see mmc_eject_media or mmc_close_tray
 
   A DriverOpException is raised on error.
 */
-void mmcStartStopMedia(bool b_eject, bool b_immediate, 
-                       uint8_t power_condition) 
+void mmcStartStopMedia(bool b_eject, bool b_immediate,
+                       uint8_t power_condition)
 {
-  driver_return_code_t drc = 
+  driver_return_code_t drc =
       mmc_start_stop_unit(p_cdio, b_eject, b_immediate, power_condition, 0);
   possible_throw_device_exception(drc);
 }
 
 
-/* 
+/*
  * Local variables:
  *  c-file-style: "gnu"
  *  tab-width: 8

--- a/include/cdio/mmc.h
+++ b/include/cdio/mmc.h
@@ -615,14 +615,6 @@ driver_return_code_t mmc_audio_get_volume (CdIo_t *p_cdio,  /*out*/
   discmode_t mmc_get_discmode( const CdIo_t *p_cdio );
 
 
-  typedef enum {
-    CDIO_MMC_LEVEL_WEIRD,
-    CDIO_MMC_LEVEL_1,
-    CDIO_MMC_LEVEL_2,
-    CDIO_MMC_LEVEL_3,
-    CDIO_MMC_LEVEL_NONE
-  } cdio_mmc_level_t;
-
   /**
     Get the MMC level supported by the device.
     @param p_cdio the CD object to be acted upon.

--- a/include/cdio/mmc.h
+++ b/include/cdio/mmc.h
@@ -633,7 +633,7 @@ cdio_mmc_level_t mmc_get_drive_mmc_cap(CdIo_t *p_cdio);
   @param p_cdio the CD object to be acted upon.
   @return MMC level supported by the device.
 */
-cdio_mmc_inquiry_version_t mmc_get_drive_mmc_cap_from_inquiry_version(CdIo_t *p_cdio);
+cdio_mmc_inquiry_version_t mmc_get_INQUIRY_version(CdIo_t *p_cdio);
 
 /**
   Get the DVD type associated with cd object.

--- a/include/cdio/mmc.h
+++ b/include/cdio/mmc.h
@@ -25,22 +25,23 @@
    The documents we make use of are described in several
    specifications made by the SCSI committee T10
    http://www.t10.org. In particular, SCSI Primary Commands (SPC),
-   SCSI Block Commands (SBC), and Multi-Media Commands (MMC). These
-   documents generally have a numeric level number appended. For
-   example SPC-3 refers to ``SCSI Primary Commands - 3'.
+   SCSI Block Commands (SBC), and Multi-Media Commands (MMC).
 
-   In year 2010 the current versions were SPC-3, SBC-2, MMC-5.
+   We will use the MMC-6 draft 2g circa 2009 described in
+   https://www.13thmonkey.org/documentation/SCSI/mmc6r02g.pdf
 
+   For a SPCS-3 we use the draft found at:
+   https://www.13thmonkey.org/documentation/SCSI/spc3r23.pdf
 */
 
 #ifndef CDIO_MMC_H_
 #define CDIO_MMC_H_
 
 #include <cdio/cdio.h>
-#include <cdio/types.h>
 #include <cdio/dvd.h>
 #include <cdio/audio.h>
 #include <cdio/mmc_util.h>
+#include <cdio/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,401 +51,393 @@ extern "C" {
    <linux/byteorder/little_endian.h>
 */
 #ifdef WORDS_BIGENDIAN
-#  if !defined(__LITTLE_ENDIAN_BITFIELD) && !defined(__BIG_ENDIAN_BITFIELD)
-#  define __MMC_BIG_ENDIAN_BITFIELD
-#  endif
+#if !defined(__LITTLE_ENDIAN_BITFIELD) && !defined(__BIG_ENDIAN_BITFIELD)
+#define __MMC_BIG_ENDIAN_BITFIELD
+#endif
 #else
-#  if !defined(__LITTLE_ENDIAN_BITFIELD) && !defined(__BIG_ENDIAN_BITFIELD)
-#  define __MMC_LITTLE_ENDIAN_BITFIELD
-#  endif
+#if !defined(__LITTLE_ENDIAN_BITFIELD) && !defined(__BIG_ENDIAN_BITFIELD)
+#define __MMC_LITTLE_ENDIAN_BITFIELD
+#endif
 #endif
 
-   /**
-      Structure of a SCSI/MMC sense reply.
+/**
+   Structure of a SCSI/MMC sense reply.
 
-      This has been adapted from GNU/Linux request_sense of <linux/cdrom.h>
-      include this for direct MMC access.
-      See SCSI Primary Commands-2 (SPC-3) table 26, page 38.
-    */
-    typedef struct cdio_mmc_request_sense {
+   This has been adapted from GNU/Linux request_sense of <linux/cdrom.h>
+   include this for direct MMC access.
+   See SCSI Primary Commands-2 (SPC-3) table 26, page 38.
+ */
+typedef struct cdio_mmc_request_sense {
 #if defined(__MMC_BIG_ENDIAN_BITFIELD)
-        uint8_t valid           : 1;  /**< valid bit is 1 if info is valid */
-        uint8_t error_code      : 7;
+  uint8_t valid : 1; /**< valid bit is 1 if info is valid */
+  uint8_t error_code : 7;
 #else
-        uint8_t error_code      : 7;
-        uint8_t valid           : 1;  /**< valid bit is 1 if info is valid */
+  uint8_t error_code : 7;
+  uint8_t valid : 1; /**< valid bit is 1 if info is valid */
 #endif
-        uint8_t segment_number;
+  uint8_t segment_number;
 #if defined(__MMC_BIG_ENDIAN_BITFIELD)
-        uint8_t filemark        : 1; /**< manditory in sequential
-                                      * access devices */
-        uint8_t eom             : 1; /**< end of medium. mandatory in
-                                      * sequential access and
-                                      * printer devices */
-        uint8_t ili             : 1; /**< incorrect length indicator */
-        uint8_t reserved1       : 1;
-        uint8_t sense_key       : 4;
+  uint8_t filemark : 1; /**< manditory in sequential
+                         * access devices */
+  uint8_t eom : 1;      /**< end of medium. mandatory in
+                         * sequential access and
+                         * printer devices */
+  uint8_t ili : 1;      /**< incorrect length indicator */
+  uint8_t reserved1 : 1;
+  uint8_t sense_key : 4;
 #else
-        uint8_t sense_key       : 4;
-        uint8_t reserved1       : 1;
-        uint8_t ili             : 1; /**< incorrect length indicator */
-        uint8_t eom             : 1; /**< end of medium. mandatory in
-                                      * sequential access and
-                                      * printer devices */
-        uint8_t filemark        : 1; /**< manditory in sequential
-                                      * access devices */
+  uint8_t sense_key : 4;
+  uint8_t reserved1 : 1;
+  uint8_t ili : 1;      /**< incorrect length indicator */
+  uint8_t eom : 1;      /**< end of medium. mandatory in
+                         * sequential access and
+                         * printer devices */
+  uint8_t filemark : 1; /**< manditory in sequential
+                         * access devices */
 #endif
-        uint8_t information[4];
-        uint8_t additional_sense_len; /**< Additional sense length (n-7) */
-        uint8_t command_info[4];      /**< Command-specific information */
-        uint8_t asc;                  /**< Additional sense code */
-        uint8_t ascq;                 /**< Additional sense code qualifier */
-        uint8_t fruc;                 /**< Field replaceable unit code */
-        uint8_t sks[3];               /**< Sense-key specific */
-        uint8_t asb[46];              /**< Additional sense bytes */
-    } cdio_mmc_request_sense_t;
+  uint8_t information[4];
+  uint8_t additional_sense_len; /**< Additional sense length (n-7) */
+  uint8_t command_info[4];      /**< Command-specific information */
+  uint8_t asc;                  /**< Additional sense code */
+  uint8_t ascq;                 /**< Additional sense code qualifier */
+  uint8_t fruc;                 /**< Field replaceable unit code */
+  uint8_t sks[3];               /**< Sense-key specific */
+  uint8_t asb[46];              /**< Additional sense bytes */
+} cdio_mmc_request_sense_t;
 
+/**
+   Meanings of the values of mmc_request_sense.sense_key
+ */
+typedef enum {
+  CDIO_MMC_SENSE_KEY_NO_SENSE = 0,
+  CDIO_MMC_SENSE_KEY_RECOVERED_ERROR = 1,
+  CDIO_MMC_SENSE_KEY_NOT_READY = 2,
+  CDIO_MMC_SENSE_KEY_MEDIUM_ERROR = 3,
+  CDIO_MMC_SENSE_KEY_HARDWARE_ERROR = 4,
+  CDIO_MMC_SENSE_KEY_ILLEGAL_REQUEST = 5,
+  CDIO_MMC_SENSE_KEY_UNIT_ATTENTION = 6,
+  CDIO_MMC_SENSE_KEY_DATA_PROTECT = 7,
+  CDIO_MMC_SENSE_KEY_BLANK_CHECK = 8,
+  CDIO_MMC_SENSE_KEY_VENDOR_SPECIFIC = 9,
+  CDIO_MMC_SENSE_KEY_COPY_ABORTED = 10,
+  CDIO_MMC_SENSE_KEY_ABORTED_COMMAND = 11,
+  CDIO_MMC_SENSE_KEY_OBSOLETE = 12,
+} cdio_mmc_sense_key_t;
 
-    /**
-       Meanings of the values of mmc_request_sense.sense_key
-     */
-    typedef enum {
-        CDIO_MMC_SENSE_KEY_NO_SENSE        =  0,
-        CDIO_MMC_SENSE_KEY_RECOVERED_ERROR =  1,
-        CDIO_MMC_SENSE_KEY_NOT_READY       =  2,
-        CDIO_MMC_SENSE_KEY_MEDIUM_ERROR    =  3,
-        CDIO_MMC_SENSE_KEY_HARDWARE_ERROR  =  4,
-        CDIO_MMC_SENSE_KEY_ILLEGAL_REQUEST =  5,
-        CDIO_MMC_SENSE_KEY_UNIT_ATTENTION  =  6,
-        CDIO_MMC_SENSE_KEY_DATA_PROTECT    =  7,
-        CDIO_MMC_SENSE_KEY_BLANK_CHECK     =  8,
-        CDIO_MMC_SENSE_KEY_VENDOR_SPECIFIC =  9,
-        CDIO_MMC_SENSE_KEY_COPY_ABORTED    = 10,
-        CDIO_MMC_SENSE_KEY_ABORTED_COMMAND = 11,
-        CDIO_MMC_SENSE_KEY_OBSOLETE        = 12,
-    } cdio_mmc_sense_key_t;
+/**
+   \brief The opcode-portion (generic packet commands) of an MMC command.
 
-    /**
-       \brief The opcode-portion (generic packet commands) of an MMC command.
+   In general, those opcodes that end in 6 take a 6-byte command
+   descriptor, those that end in 10 take a 10-byte
+   descriptor, and those that end in 12 take a 12-byte descriptor.
 
-       In general, those opcodes that end in 6 take a 6-byte command
-       descriptor, those that end in 10 take a 10-byte
-       descriptor, and those that end in 12 take a 12-byte descriptor.
+   (Not that you need to know that, but it seems to be a
+   big deal in the MMC specification.)
 
-       (Not that you need to know that, but it seems to be a
-       big deal in the MMC specification.)
-
-    */
-    typedef enum {
-  CDIO_MMC_GPCMD_TEST_UNIT_READY        = 0x00, /**< test if drive ready. */
-  CDIO_MMC_GPCMD_REQUEST_SENSE          = 0x03,
-  CDIO_MMC_GPCMD_FORMAT_UNIT            = 0x04,
-  CDIO_MMC_GPCMD_INQUIRY                = 0x12, /**< Request drive
-                                                   information. */
-  CDIO_MMC_GPCMD_MODE_SELECT_6          = 0x15, /**< Select medium
-                                                   (6 bytes). */
-  CDIO_MMC_GPCMD_MODE_SENSE_6           = 0x1a, /**< Get medium or device
-                                                 information. Should be issued
-                                                 before MODE SELECT to get
-                                                 mode support or save current
-                                                 settings. (6 bytes). */
-  CDIO_MMC_GPCMD_START_STOP_UNIT        = 0x1b, /**< Enable/disable Disc
-                                                     operations. (6 bytes). */
-  CDIO_MMC_GPCMD_PREVENT_ALLOW_MEDIUM_REMOVAL
-                                        = 0x1e, /**< Enable/disable Disc
-                                                   removal. (6 bytes). */
+*/
+typedef enum {
+  CDIO_MMC_GPCMD_TEST_UNIT_READY = 0x00, /**< test if drive ready. */
+  CDIO_MMC_GPCMD_REQUEST_SENSE = 0x03,
+  CDIO_MMC_GPCMD_FORMAT_UNIT = 0x04,
+  CDIO_MMC_GPCMD_INQUIRY = 0x12,                      /**< Request drive
+                                                         information. */
+  CDIO_MMC_GPCMD_MODE_SELECT_6 = 0x15,                /**< Select medium
+                                                         (6 bytes). */
+  CDIO_MMC_GPCMD_MODE_SENSE_6 = 0x1a,                 /**< Get medium or device
+                                                       information. Should be issued
+                                                       before MODE SELECT to get
+                                                       mode support or save current
+                                                       settings. (6 bytes). */
+  CDIO_MMC_GPCMD_START_STOP_UNIT = 0x1b,              /**< Enable/disable Disc
+                                                           operations. (6 bytes). */
+  CDIO_MMC_GPCMD_PREVENT_ALLOW_MEDIUM_REMOVAL = 0x1e, /**< Enable/disable Disc
+                                                         removal. (6 bytes). */
 
   /**
       Group 2 Commands (CDB's here are 10-bytes)
   */
   CDIO_MMC_GPCMD_READ_FORMAT_CAPACITIES = 0x23, /**< MMC-5 Section 6.24 */
-  CDIO_MMC_GPCMD_READ_CAPACITIY         = 0x25, /**< MMC-5 Section 6.19 */
-  CDIO_MMC_GPCMD_READ_10                = 0x28, /**< Read data from drive
+  CDIO_MMC_GPCMD_READ_CAPACITIY = 0x25,         /**< MMC-5 Section 6.19 */
+  CDIO_MMC_GPCMD_READ_10 = 0x28,                /**< Read data from drive
                                                    (10 bytes). */
-  CDIO_MMC_GPCMD_WRITE_10               = 0x2a,
-  CDIO_MMC_GPCMD_SEEK_10                = 0x2b,
-  CDIO_MMC_GPCMD_ERASE_10               = 0x2c, /**< MMC5 Section 6.4 */
-  CDIO_MMC_GPCMD_WRITE_AND_VERIFY_10    = 0x2e,
-  CDIO_MMC_GPCMD_VERIFY_10              = 0x2f,
-  CDIO_MMC_GPCMD_SYNCHRONIZE_CACHE      = 0x35,
-  CDIO_MMC_GPCMD_WRITE_BUFFER           = 0x3b,
-  CDIO_MMC_GPCMD_READ_BUFFER            = 0x3c,
-  CDIO_MMC_GPCMD_READ_SUBCHANNEL        = 0x42, /**< Read Sub-Channel data.
-                                                   (10 bytes). */
-  CDIO_MMC_GPCMD_READ_TOC               = 0x43, /**< READ TOC/PMA/ATIP.
-                                                   (10 bytes). */
-  CDIO_MMC_GPCMD_READ_HEADER            = 0x44,
-  CDIO_MMC_GPCMD_PLAY_AUDIO_10          = 0x45, /**< Begin audio playing at
-                                                   current position
-                                                   (10 bytes). */
-  CDIO_MMC_GPCMD_GET_CONFIGURATION      = 0x46, /**< Get drive Capabilities
-                                                   (10 bytes) */
-  CDIO_MMC_GPCMD_PLAY_AUDIO_MSF         = 0x47, /**< Begin audio playing at
-                                                   specified MSF (10
-                                                   bytes). */
-  CDIO_MMC_GPCMD_PLAY_AUDIO_TI          = 0x48,
-  CDIO_MMC_GPCMD_PLAY_TRACK_REL_10      = 0x49, /**< Play audio at the track
-                                                   relative LBA. (10 bytes).
-                                                   Doesn't seem to be part
-                                                   of MMC standards but is
-                                                   handled by Plextor drives.
-                                                */
+  CDIO_MMC_GPCMD_WRITE_10 = 0x2a,
+  CDIO_MMC_GPCMD_SEEK_10 = 0x2b,
+  CDIO_MMC_GPCMD_ERASE_10 = 0x2c, /**< MMC5 Section 6.4 */
+  CDIO_MMC_GPCMD_WRITE_AND_VERIFY_10 = 0x2e,
+  CDIO_MMC_GPCMD_VERIFY_10 = 0x2f,
+  CDIO_MMC_GPCMD_SYNCHRONIZE_CACHE = 0x35,
+  CDIO_MMC_GPCMD_WRITE_BUFFER = 0x3b,
+  CDIO_MMC_GPCMD_READ_BUFFER = 0x3c,
+  CDIO_MMC_GPCMD_READ_SUBCHANNEL = 0x42, /**< Read Sub-Channel data.
+                                            (10 bytes). */
+  CDIO_MMC_GPCMD_READ_TOC = 0x43,        /**< READ TOC/PMA/ATIP.
+                                            (10 bytes). */
+  CDIO_MMC_GPCMD_READ_HEADER = 0x44,
+  CDIO_MMC_GPCMD_PLAY_AUDIO_10 = 0x45,     /**< Begin audio playing at
+                                              current position
+                                              (10 bytes). */
+  CDIO_MMC_GPCMD_GET_CONFIGURATION = 0x46, /**< Get drive Capabilities
+                                              (10 bytes) */
+  CDIO_MMC_GPCMD_PLAY_AUDIO_MSF = 0x47,    /**< Begin audio playing at
+                                              specified MSF (10
+                                              bytes). */
+  CDIO_MMC_GPCMD_PLAY_AUDIO_TI = 0x48,
+  CDIO_MMC_GPCMD_PLAY_TRACK_REL_10 = 0x49, /**< Play audio at the track
+                                              relative LBA. (10 bytes).
+                                              Doesn't seem to be part
+                                              of MMC standards but is
+                                              handled by Plextor drives.
+                                           */
 
-  CDIO_MMC_GPCMD_GET_EVENT_STATUS       = 0x4a, /**< Report events and
-                                                   Status. */
-  CDIO_MMC_GPCMD_PAUSE_RESUME           = 0x4b, /**< Stop or restart audio
-                                                   playback. (10 bytes).
-                                                   Used with a PLAY command. */
+  CDIO_MMC_GPCMD_GET_EVENT_STATUS = 0x4a, /**< Report events and
+                                             Status. */
+  CDIO_MMC_GPCMD_PAUSE_RESUME = 0x4b,     /**< Stop or restart audio
+                                             playback. (10 bytes).
+                                             Used with a PLAY command. */
 
-  CDIO_MMC_GPCMD_READ_DISC_INFORMATION  = 0x51, /**< Get CD information.
+  CDIO_MMC_GPCMD_READ_DISC_INFORMATION = 0x51,  /**< Get CD information.
                                                    (10 bytes). */
   CDIO_MMC_GPCMD_READ_TRACK_INFORMATION = 0x52, /**< Information about a
                                                    logical track. */
-  CDIO_MMC_GPCMD_RESERVE_TRACK          = 0x53,
-  CDIO_MMC_GPCMD_SEND_OPC_INFORMATION   = 0x54,
-  CDIO_MMC_GPCMD_MODE_SELECT_10         = 0x55, /**< Select medium
-                                                   (10-bytes). */
-  CDIO_MMC_GPCMD_REPAIR_TRACK           = 0x58,
-  CDIO_MMC_GPCMD_MODE_SENSE_10          = 0x5a, /**< Get medium or device
-                                                 information. Should be issued
-                                                 before MODE SELECT to get
-                                                 mode support or save current
-                                                 settings. (6 bytes). */
-  CDIO_MMC_GPCMD_CLOSE_TRACK_SESSION    = 0x5b,
-  CDIO_MMC_GPCMD_READ_BUFFER_CAPACITY   = 0x5c,
-  CDIO_MMC_GPCMD_SEND_CUE_SHEET         = 0x5d,
+  CDIO_MMC_GPCMD_RESERVE_TRACK = 0x53,
+  CDIO_MMC_GPCMD_SEND_OPC_INFORMATION = 0x54,
+  CDIO_MMC_GPCMD_MODE_SELECT_10 = 0x55, /**< Select medium
+                                           (10-bytes). */
+  CDIO_MMC_GPCMD_REPAIR_TRACK = 0x58,
+  CDIO_MMC_GPCMD_MODE_SENSE_10 = 0x5a, /**< Get medium or device
+                                        information. Should be issued
+                                        before MODE SELECT to get
+                                        mode support or save current
+                                        settings. (6 bytes). */
+  CDIO_MMC_GPCMD_CLOSE_TRACK_SESSION = 0x5b,
+  CDIO_MMC_GPCMD_READ_BUFFER_CAPACITY = 0x5c,
+  CDIO_MMC_GPCMD_SEND_CUE_SHEET = 0x5d,
 
   /**
       Group 5 Commands (CDB's here are 12-bytes)
   */
-  CDIO_MMC_GPCMD_REPORT_LUNS            = 0xa0,
-  CDIO_MMC_GPCMD_BLANK                  = 0xa1,
-  CDIO_MMC_GPCMD_SECURITY_PROTOCOL_IN   = 0xa2,
-  CDIO_MMC_GPCMD_SEND_KEY               = 0xa3,
-  CDIO_MMC_GPCMD_REPORT_KEY             = 0xa4,
-  CDIO_MMC_GPCMD_PLAY_AUDIO_12          = 0xa5, /**< Begin audio playing at
-                                                   current position
-                                                 (12 bytes) */
-  CDIO_MMC_GPCMD_LOAD_UNLOAD            = 0xa6, /**< Load/unload a Disc
-                                                 (12 bytes) */
-  CDIO_MMC_GPCMD_SET_READ_AHEAD         = 0xa7,
-  CDIO_MMC_GPCMD_READ_12                = 0xa8, /**< Read data from drive
-                                                   (12 bytes). */
-  CDIO_MMC_GPCMD_PLAY_TRACK_REL_12      = 0xa9, /**< Play audio at the track
-                                                   relative LBA. (12 bytes).
-                                                   Doesn't seem to be part
-                                                   of MMC standards but is
-                                                   handled by Plextor drives.
-                                                */
-  CDIO_MMC_GPCMD_WRITE_12               = 0xaa,
-  CDIO_MMC_GPCMD_READ_MEDIA_SERIAL_12   = 0xab, /**< MMC-5 Section 6.25 */
-  CDIO_MMC_GPCMD_GET_PERFORMANCE        = 0xac,
-  CDIO_MMC_GPCMD_READ_DVD_STRUCTURE     = 0xad, /**< Get DVD structure info
-                                                   from media (12 bytes). */
-  CDIO_MMC_GPCMD_SECURITY_PROTOCOL_OUT  = 0xb5,
-  CDIO_MMC_GPCMD_SET_STREAMING          = 0xb6,
-  CDIO_MMC_GPCMD_READ_MSF               = 0xb9, /**< Read almost any field
-                                                   of a CD sector at specified
-                                                   MSF. (12 bytes). */
-  CDIO_MMC_GPCMD_SET_SPEED              = 0xbb, /**< Set drive speed
-                                                   (12 bytes). This is listed
-                                                   as optional in ATAPI 2.6,
-                                                   but is (curiously)
-                                                   missing from Mt. Fuji,
-                                                   Table 57. It is mentioned
-                                                   in Mt. Fuji Table 377 as an
-                                                   MMC command for SCSI
-                                                   devices though...  Most
-                                                   ATAPI drives support it. */
-  CDIO_MMC_GPCMD_MECHANISM_STATUS       = 0xbd,
-  CDIO_MMC_GPCMD_READ_CD                = 0xbe, /**< Read almost any field
-                                                   of a CD sector at current
-                                                   location. (12 bytes). */
-  CDIO_MMC_GPCMD_SEND_DISC_STRUCTURE    = 0xbf,
+  CDIO_MMC_GPCMD_REPORT_LUNS = 0xa0,
+  CDIO_MMC_GPCMD_BLANK = 0xa1,
+  CDIO_MMC_GPCMD_SECURITY_PROTOCOL_IN = 0xa2,
+  CDIO_MMC_GPCMD_SEND_KEY = 0xa3,
+  CDIO_MMC_GPCMD_REPORT_KEY = 0xa4,
+  CDIO_MMC_GPCMD_PLAY_AUDIO_12 = 0xa5, /**< Begin audio playing at
+                                          current position
+                                        (12 bytes) */
+  CDIO_MMC_GPCMD_LOAD_UNLOAD = 0xa6,   /**< Load/unload a Disc
+                                        (12 bytes) */
+  CDIO_MMC_GPCMD_SET_READ_AHEAD = 0xa7,
+  CDIO_MMC_GPCMD_READ_12 = 0xa8,           /**< Read data from drive
+                                              (12 bytes). */
+  CDIO_MMC_GPCMD_PLAY_TRACK_REL_12 = 0xa9, /**< Play audio at the track
+                                              relative LBA. (12 bytes).
+                                              Doesn't seem to be part
+                                              of MMC standards but is
+                                              handled by Plextor drives.
+                                           */
+  CDIO_MMC_GPCMD_WRITE_12 = 0xaa,
+  CDIO_MMC_GPCMD_READ_MEDIA_SERIAL_12 = 0xab, /**< MMC-5 Section 6.25 */
+  CDIO_MMC_GPCMD_GET_PERFORMANCE = 0xac,
+  CDIO_MMC_GPCMD_READ_DVD_STRUCTURE = 0xad, /**< Get DVD structure info
+                                               from media (12 bytes). */
+  CDIO_MMC_GPCMD_SECURITY_PROTOCOL_OUT = 0xb5,
+  CDIO_MMC_GPCMD_SET_STREAMING = 0xb6,
+  CDIO_MMC_GPCMD_READ_MSF = 0xb9,  /**< Read almost any field
+                                      of a CD sector at specified
+                                      MSF. (12 bytes). */
+  CDIO_MMC_GPCMD_SET_SPEED = 0xbb, /**< Set drive speed
+                                      (12 bytes). This is listed
+                                      as optional in ATAPI 2.6,
+                                      but is (curiously)
+                                      missing from Mt. Fuji,
+                                      Table 57. It is mentioned
+                                      in Mt. Fuji Table 377 as an
+                                      MMC command for SCSI
+                                      devices though...  Most
+                                      ATAPI drives support it. */
+  CDIO_MMC_GPCMD_MECHANISM_STATUS = 0xbd,
+  CDIO_MMC_GPCMD_READ_CD = 0xbe, /**< Read almost any field
+                                    of a CD sector at current
+                                    location. (12 bytes). */
+  CDIO_MMC_GPCMD_SEND_DISC_STRUCTURE = 0xbf,
   /**
       Vendor-unique Commands
   */
-  CDIO_MMC_GPCMD_CD_PLAYBACK_STATUS  = 0xc4 /**< SONY unique  = command */,
-  CDIO_MMC_GPCMD_PLAYBACK_CONTROL    = 0xc9 /**< SONY unique  = command */,
-  CDIO_MMC_GPCMD_READ_CDDA           = 0xd8 /**< Vendor unique  = command */,
-  CDIO_MMC_GPCMD_READ_CDXA           = 0xdb /**< Vendor unique  = command */,
-  CDIO_MMC_GPCMD_READ_ALL_SUBCODES   = 0xdf /**< Vendor unique  = command */
-  } cdio_mmc_gpcmd_t;
+  CDIO_MMC_GPCMD_CD_PLAYBACK_STATUS = 0xc4 /**< SONY unique  = command */,
+  CDIO_MMC_GPCMD_PLAYBACK_CONTROL = 0xc9 /**< SONY unique  = command */,
+  CDIO_MMC_GPCMD_READ_CDDA = 0xd8 /**< Vendor unique  = command */,
+  CDIO_MMC_GPCMD_READ_CDXA = 0xdb /**< Vendor unique  = command */,
+  CDIO_MMC_GPCMD_READ_ALL_SUBCODES = 0xdf /**< Vendor unique  = command */
+} cdio_mmc_gpcmd_t;
 
-  /**
-      Read Subchannel states
-  */
-  typedef enum {
-    CDIO_MMC_READ_SUB_ST_INVALID   = 0x00, /**< audio status not supported */
-    CDIO_MMC_READ_SUB_ST_PLAY      = 0x11, /**< audio play operation in
-                                              progress */
-    CDIO_MMC_READ_SUB_ST_PAUSED    = 0x12, /**< audio play operation paused */
-    CDIO_MMC_READ_SUB_ST_COMPLETED = 0x13, /**< audio play successfully
-                                              completed */
-    CDIO_MMC_READ_SUB_ST_ERROR     = 0x14, /**< audio play stopped due to
-                                              error */
-    CDIO_MMC_READ_SUB_ST_NO_STATUS = 0x15, /**< no current audio status to
-                                              return */
-  } cdio_mmc_read_sub_state_t;
+/**
+    Read Subchannel states
+*/
+typedef enum {
+  CDIO_MMC_READ_SUB_ST_INVALID = 0x00,   /**< audio status not supported */
+  CDIO_MMC_READ_SUB_ST_PLAY = 0x11,      /**< audio play operation in
+                                            progress */
+  CDIO_MMC_READ_SUB_ST_PAUSED = 0x12,    /**< audio play operation paused */
+  CDIO_MMC_READ_SUB_ST_COMPLETED = 0x13, /**< audio play successfully
+                                            completed */
+  CDIO_MMC_READ_SUB_ST_ERROR = 0x14,     /**< audio play stopped due to
+                                            error */
+  CDIO_MMC_READ_SUB_ST_NO_STATUS = 0x15, /**< no current audio status to
+                                            return */
+} cdio_mmc_read_sub_state_t;
 
-  /** Level values that can go into READ_CD */
-  typedef enum {
-    CDIO_MMC_READ_TYPE_ANY  =  0,  /**< All types */
-    CDIO_MMC_READ_TYPE_CDDA =  1,  /**< Only CD-DA sectors */
-    CDIO_MMC_READ_TYPE_MODE1 = 2,  /**< mode1 sectors (user data = 2048) */
-    CDIO_MMC_READ_TYPE_MODE2 = 3,  /**< mode2 sectors form1 or form2 */
-    CDIO_MMC_READ_TYPE_M2F1 =  4,  /**< mode2 sectors form1 */
-    CDIO_MMC_READ_TYPE_M2F2 =  5   /**< mode2 sectors form2 */
-  } cdio_mmc_read_cd_type_t;
+/** Level values that can go into READ_CD */
+typedef enum {
+  CDIO_MMC_READ_TYPE_ANY = 0,   /**< All types */
+  CDIO_MMC_READ_TYPE_CDDA = 1,  /**< Only CD-DA sectors */
+  CDIO_MMC_READ_TYPE_MODE1 = 2, /**< mode1 sectors (user data = 2048) */
+  CDIO_MMC_READ_TYPE_MODE2 = 3, /**< mode2 sectors form1 or form2 */
+  CDIO_MMC_READ_TYPE_M2F1 = 4,  /**< mode2 sectors form1 */
+  CDIO_MMC_READ_TYPE_M2F2 = 5   /**< mode2 sectors form2 */
+} cdio_mmc_read_cd_type_t;
 
-  /**
-      Format values for READ_TOC
-  */
-  typedef enum {
-    CDIO_MMC_READTOC_FMT_TOC     =  0,
-    CDIO_MMC_READTOC_FMT_SESSION =  1,
-    CDIO_MMC_READTOC_FMT_FULTOC  =  2,
-    CDIO_MMC_READTOC_FMT_PMA     =  3,  /**< Q subcode data */
-    CDIO_MMC_READTOC_FMT_ATIP    =  4,  /**< includes media type */
-    CDIO_MMC_READTOC_FMT_CDTEXT  =  5   /**< CD-TEXT info  */
-  } cdio_mmc_readtoc_t;
+/**
+    Format values for READ_TOC
+*/
+typedef enum {
+  CDIO_MMC_READTOC_FMT_TOC = 0,
+  CDIO_MMC_READTOC_FMT_SESSION = 1,
+  CDIO_MMC_READTOC_FMT_FULTOC = 2,
+  CDIO_MMC_READTOC_FMT_PMA = 3,   /**< Q subcode data */
+  CDIO_MMC_READTOC_FMT_ATIP = 4,  /**< includes media type */
+  CDIO_MMC_READTOC_FMT_CDTEXT = 5 /**< CD-TEXT info  */
+} cdio_mmc_readtoc_t;
 
-  /**
-     Page codes for MODE SENSE and MODE SET.
-  */
-  typedef enum {
-      CDIO_MMC_R_W_ERROR_PAGE     = 0x01,
-      CDIO_MMC_WRITE_PARMS_PAGE   = 0x05,
-      CDIO_MMC_CDR_PARMS_PAGE     = 0x0d,
-      CDIO_MMC_AUDIO_CTL_PAGE     = 0x0e,
-      CDIO_MMC_POWER_PAGE         = 0x1a,
-      CDIO_MMC_FAULT_FAIL_PAGE    = 0x1c,
-      CDIO_MMC_TO_PROTECT_PAGE    = 0x1d,
-      CDIO_MMC_CAPABILITIES_PAGE  = 0x2a,
-      CDIO_MMC_ALL_PAGES          = 0x3f,
-  } cdio_mmc_mode_page_t;
+/**
+   Page codes for MODE SENSE and MODE SET.
+*/
+typedef enum {
+  CDIO_MMC_R_W_ERROR_PAGE = 0x01,
+  CDIO_MMC_WRITE_PARMS_PAGE = 0x05,
+  CDIO_MMC_CDR_PARMS_PAGE = 0x0d,
+  CDIO_MMC_AUDIO_CTL_PAGE = 0x0e,
+  CDIO_MMC_POWER_PAGE = 0x1a,
+  CDIO_MMC_FAULT_FAIL_PAGE = 0x1c,
+  CDIO_MMC_TO_PROTECT_PAGE = 0x1d,
+  CDIO_MMC_CAPABILITIES_PAGE = 0x2a,
+  CDIO_MMC_ALL_PAGES = 0x3f,
+} cdio_mmc_mode_page_t;
 
- /**
-    READ DISC INFORMATION Data Types
- */
-  typedef enum {
-      CDIO_MMC_READ_DISC_INFO_STANDARD   = 0x0,
-      CDIO_MMC_READ_DISC_INFO_TRACK      = 0x1,
-      CDIO_MMC_READ_DISC_INFO_POW        = 0x2,
-  } cdio_mmc_read_disc_info_datatype_t;
+/**
+   READ DISC INFORMATION Data Types
+*/
+typedef enum {
+  CDIO_MMC_READ_DISC_INFO_STANDARD = 0x0,
+  CDIO_MMC_READ_DISC_INFO_TRACK = 0x1,
+  CDIO_MMC_READ_DISC_INFO_POW = 0x2,
+} cdio_mmc_read_disc_info_datatype_t;
 
 /* For backward compatibility. */
 #define CDIO_MMC_GPCMD_READ_DISC_INFO CDIO_MMC_GPCMD_READ_DISC_INFORMATION
 #define CDIO_MMC_GPCMD_READ_DISC_STRUCTURE CDIO_MMC_GPMD_READ_DVD_STRUCTURE
 
-
 PRAGMA_BEGIN_PACKED
-  struct mmc_audio_volume_entry_s
-  {
-    uint8_t  selection; /* Only the lower 4 bits are used. */
-    uint8_t  volume;
-  } GNUC_PACKED;
+struct mmc_audio_volume_entry_s {
+  uint8_t selection; /* Only the lower 4 bits are used. */
+  uint8_t volume;
+} GNUC_PACKED;
 
-  typedef struct mmc_audio_volume_entry_s mmc_audio_volume_entry_t;
+typedef struct mmc_audio_volume_entry_s mmc_audio_volume_entry_t;
 
-  /**
-      This struct is used by cdio_audio_get_volume and cdio_audio_set_volume
-  */
-  struct mmc_audio_volume_s
-  {
-    mmc_audio_volume_entry_t port[4];
-  } GNUC_PACKED;
+/**
+    This struct is used by cdio_audio_get_volume and cdio_audio_set_volume
+*/
+struct mmc_audio_volume_s {
+  mmc_audio_volume_entry_t port[4];
+} GNUC_PACKED;
 
-  typedef struct mmc_audio_volume_s mmc_audio_volume_t;
+typedef struct mmc_audio_volume_s mmc_audio_volume_t;
 
 PRAGMA_END_PACKED
-
 
 /**
     Return type codes for GET_CONFIGURATION.
 */
 typedef enum {
-  CDIO_MMC_GET_CONF_ALL_FEATURES     = 0,  /**< all features without regard
-                                              to currency. */
-  CDIO_MMC_GET_CONF_CURRENT_FEATURES = 1,  /**< features which are currently
-                                              in effect (e.g. based on
-                                              medium inserted). */
-  CDIO_MMC_GET_CONF_NAMED_FEATURE    = 2   /**< just the feature named in
-                                              the GET_CONFIGURATION cdb. */
+  CDIO_MMC_GET_CONF_ALL_FEATURES = 0,     /**< all features without regard
+                                             to currency. */
+  CDIO_MMC_GET_CONF_CURRENT_FEATURES = 1, /**< features which are currently
+                                             in effect (e.g. based on
+                                             medium inserted). */
+  CDIO_MMC_GET_CONF_NAMED_FEATURE = 2     /**< just the feature named in
+                                             the GET_CONFIGURATION cdb. */
 } cdio_mmc_get_conf_t;
-
 
 /**
     FEATURE codes used in GET CONFIGURATION.
 */
 typedef enum {
-  CDIO_MMC_FEATURE_PROFILE_LIST     = 0x000, /**< Profile List Feature */
-  CDIO_MMC_FEATURE_CORE             = 0x001,
-  CDIO_MMC_FEATURE_MORPHING         = 0x002, /**< Report/prevent operational
-                                                  changes  */
-  CDIO_MMC_FEATURE_REMOVABLE_MEDIUM = 0x003, /**< Removable Medium Feature */
-  CDIO_MMC_FEATURE_WRITE_PROTECT    = 0x004, /**< Write Protect Feature */
-  CDIO_MMC_FEATURE_RANDOM_READABLE  = 0x010, /**< Random Readable Feature */
-  CDIO_MMC_FEATURE_MULTI_READ       = 0x01D, /**< Multi-Read Feature */
-  CDIO_MMC_FEATURE_CD_READ          = 0x01E, /**< CD Read Feature */
-  CDIO_MMC_FEATURE_DVD_READ         = 0x01F, /**< DVD Read Feature */
-  CDIO_MMC_FEATURE_RANDOM_WRITABLE  = 0x020, /**< Random Writable Feature */
-  CDIO_MMC_FEATURE_INCR_WRITE       = 0x021, /**< Incremental Streaming
-                                                Writable Feature */
-  CDIO_MMC_FEATURE_SECTOR_ERASE     = 0x022, /**< Sector Erasable Feature */
-  CDIO_MMC_FEATURE_FORMATABLE       = 0x023, /**< Formattable Feature */
-  CDIO_MMC_FEATURE_DEFECT_MGMT      = 0x024, /**< Management Ability of the
-                                                Logical Unit/media system to
-                                                provide an apparently
-                                                defect-free space.*/
-  CDIO_MMC_FEATURE_WRITE_ONCE       = 0x025, /**< Write Once
-                                                   Feature */
-  CDIO_MMC_FEATURE_RESTRICT_OVERW   = 0x026, /**< Restricted Overwrite
-                                                Feature */
-  CDIO_MMC_FEATURE_CD_RW_CAV        = 0x027, /**< CD-RW CAV Write Feature */
-  CDIO_MMC_FEATURE_MRW              = 0x028, /**< MRW Feature */
-  CDIO_MMC_FEATURE_ENHANCED_DEFECT  = 0x029, /**< Enhanced Defect Reporting */
-  CDIO_MMC_FEATURE_DVD_PRW          = 0x02A, /**< DVD+RW Feature */
-  CDIO_MMC_FEATURE_DVD_PR           = 0x02B, /**< DVD+R Feature */
-  CDIO_MMC_FEATURE_RIGID_RES_OVERW  = 0x02C, /**< Rigid Restricted Overwrite */
-  CDIO_MMC_FEATURE_CD_TAO           = 0x02D, /**< CD Track at Once */
-  CDIO_MMC_FEATURE_CD_SAO           = 0x02E, /**< CD Mastering (Session at
-                                                Once) */
-  CDIO_MMC_FEATURE_DVD_R_RW_WRITE   = 0x02F, /**< DVD-R/RW Write */
-  CDIO_MMC_FEATURE_CD_RW_MEDIA_WRITE= 0x037, /**< CD-RW Media Write Support */
-  CDIO_MMC_FEATURE_DVD_PR_2_LAYER   = 0x03B, /**< DVD+R Double Layer */
-  CDIO_MMC_FEATURE_POWER_MGMT       = 0x100, /**< Initiator and device directed
-                                                power management */
-  CDIO_MMC_FEATURE_CDDA_EXT_PLAY    = 0x103, /**< Ability to play audio CDs
-                                                via the Logical Unit's own
-                                                analog output */
-  CDIO_MMC_FEATURE_MCODE_UPGRADE    = 0x104, /* Ability for the device to
-                                                accept  new microcode via
-                                                the interface */
-  CDIO_MMC_FEATURE_TIME_OUT         = 0x105, /**< Ability to respond to all
-                                                commands within a specific
-                                                time */
-  CDIO_MMC_FEATURE_DVD_CSS          = 0x106, /**< Ability to perform DVD
-                                                CSS/CPPM authentication and
-                                                RPC */
-  CDIO_MMC_FEATURE_RT_STREAMING     = 0x107, /**< Ability to read and write
-                                                using Initiator requested
-                                                performance parameters   */
-  CDIO_MMC_FEATURE_LU_SN            = 0x108, /**< The Logical Unit has a unique
-                                                identifier. */
-  CDIO_MMC_FEATURE_FIRMWARE_DATE    = 0x1FF, /**< Firmware creation date
-                                                report */
+  CDIO_MMC_FEATURE_PROFILE_LIST = 0x000, /**< Profile List Feature */
+  CDIO_MMC_FEATURE_CORE = 0x001,
+  CDIO_MMC_FEATURE_MORPHING = 0x002,          /**< Report/prevent operational
+                                                   changes  */
+  CDIO_MMC_FEATURE_REMOVABLE_MEDIUM = 0x003,  /**< Removable Medium Feature */
+  CDIO_MMC_FEATURE_WRITE_PROTECT = 0x004,     /**< Write Protect Feature */
+  CDIO_MMC_FEATURE_RANDOM_READABLE = 0x010,   /**< Random Readable Feature */
+  CDIO_MMC_FEATURE_MULTI_READ = 0x01D,        /**< Multi-Read Feature */
+  CDIO_MMC_FEATURE_CD_READ = 0x01E,           /**< CD Read Feature */
+  CDIO_MMC_FEATURE_DVD_READ = 0x01F,          /**< DVD Read Feature */
+  CDIO_MMC_FEATURE_RANDOM_WRITABLE = 0x020,   /**< Random Writable Feature */
+  CDIO_MMC_FEATURE_INCR_WRITE = 0x021,        /**< Incremental Streaming
+                                                 Writable Feature */
+  CDIO_MMC_FEATURE_SECTOR_ERASE = 0x022,      /**< Sector Erasable Feature */
+  CDIO_MMC_FEATURE_FORMATABLE = 0x023,        /**< Formattable Feature */
+  CDIO_MMC_FEATURE_DEFECT_MGMT = 0x024,       /**< Management Ability of the
+                                                 Logical Unit/media system to
+                                                 provide an apparently
+                                                 defect-free space.*/
+  CDIO_MMC_FEATURE_WRITE_ONCE = 0x025,        /**< Write Once
+                                                    Feature */
+  CDIO_MMC_FEATURE_RESTRICT_OVERW = 0x026,    /**< Restricted Overwrite
+                                                 Feature */
+  CDIO_MMC_FEATURE_CD_RW_CAV = 0x027,         /**< CD-RW CAV Write Feature */
+  CDIO_MMC_FEATURE_MRW = 0x028,               /**< MRW Feature */
+  CDIO_MMC_FEATURE_ENHANCED_DEFECT = 0x029,   /**< Enhanced Defect Reporting */
+  CDIO_MMC_FEATURE_DVD_PRW = 0x02A,           /**< DVD+RW Feature */
+  CDIO_MMC_FEATURE_DVD_PR = 0x02B,            /**< DVD+R Feature */
+  CDIO_MMC_FEATURE_RIGID_RES_OVERW = 0x02C,   /**< Rigid Restricted Overwrite */
+  CDIO_MMC_FEATURE_CD_TAO = 0x02D,            /**< CD Track at Once */
+  CDIO_MMC_FEATURE_CD_SAO = 0x02E,            /**< CD Mastering (Session at
+                                                 Once) */
+  CDIO_MMC_FEATURE_DVD_R_RW_WRITE = 0x02F,    /**< DVD-R/RW Write */
+  CDIO_MMC_FEATURE_CD_RW_MEDIA_WRITE = 0x037, /**< CD-RW Media Write Support */
+  CDIO_MMC_FEATURE_DVD_PR_2_LAYER = 0x03B,    /**< DVD+R Double Layer */
+  CDIO_MMC_FEATURE_POWER_MGMT = 0x100,        /**< Initiator and device directed
+                                                 power management */
+  CDIO_MMC_FEATURE_CDDA_EXT_PLAY = 0x103,     /**< Ability to play audio CDs
+                                                 via the Logical Unit's own
+                                                 analog output */
+  CDIO_MMC_FEATURE_MCODE_UPGRADE = 0x104,     /* Ability for the device to
+                                                 accept  new microcode via
+                                                 the interface */
+  CDIO_MMC_FEATURE_TIME_OUT = 0x105,          /**< Ability to respond to all
+                                                 commands within a specific
+                                                 time */
+  CDIO_MMC_FEATURE_DVD_CSS = 0x106,           /**< Ability to perform DVD
+                                                 CSS/CPPM authentication and
+                                                 RPC */
+  CDIO_MMC_FEATURE_RT_STREAMING = 0x107,      /**< Ability to read and write
+                                                 using Initiator requested
+                                                 performance parameters   */
+  CDIO_MMC_FEATURE_LU_SN = 0x108,             /**< The Logical Unit has a unique
+                                                 identifier. */
+  CDIO_MMC_FEATURE_FIRMWARE_DATE = 0x1FF,     /**< Firmware creation date
+                                                 report */
 } cdio_mmc_feature_t;
 
 typedef enum {
   CDIO_MMC_FEATURE_INTERFACE_UNSPECIFIED = 0,
-  CDIO_MMC_FEATURE_INTERFACE_SCSI        = 1,
-  CDIO_MMC_FEATURE_INTERFACE_ATAPI       = 2,
-  CDIO_MMC_FEATURE_INTERFACE_IEEE_1394   = 3,
-  CDIO_MMC_FEATURE_INTERFACE_IEEE_1394A  = 4,
-  CDIO_MMC_FEATURE_INTERFACE_FIBRE_CH    = 5
+  CDIO_MMC_FEATURE_INTERFACE_SCSI = 1,
+  CDIO_MMC_FEATURE_INTERFACE_ATAPI = 2,
+  CDIO_MMC_FEATURE_INTERFACE_IEEE_1394 = 3,
+  CDIO_MMC_FEATURE_INTERFACE_IEEE_1394A = 4,
+  CDIO_MMC_FEATURE_INTERFACE_FIBRE_CH = 5
 } cdio_mmc_feature_interface_t;
-
 
 /**
     The largest Command Descriptor Block (CDB) size.
@@ -460,98 +453,88 @@ typedef struct mmc_cdb_s {
   uint8_t field[MAX_CDB_LEN];
 } mmc_cdb_t;
 
-  /**
-      \brief Format of header block in data returned from an MMC
-    GET_CONFIGURATION command.
-  */
-  typedef struct mmc_feature_list_header_s {
-    unsigned char length_msb;
-    unsigned char length_1sb;
-    unsigned char length_2sb;
-    unsigned char length_lsb;
-    unsigned char reserved1;
-    unsigned char reserved2;
-    unsigned char profile_msb;
-    unsigned char profile_lsb;
-  } cdio_mmc_feature_list_header_t;
+/**
+    \brief Format of header block in data returned from an MMC
+  GET_CONFIGURATION command.
+*/
+typedef struct mmc_feature_list_header_s {
+  unsigned char length_msb;
+  unsigned char length_1sb;
+  unsigned char length_2sb;
+  unsigned char length_lsb;
+  unsigned char reserved1;
+  unsigned char reserved2;
+  unsigned char profile_msb;
+  unsigned char profile_lsb;
+} cdio_mmc_feature_list_header_t;
 
-  /**
-      An enumeration indicating whether an MMC command is sending
-      data, or getting data, both, or neither.
-  */
-  typedef enum mmc_direction_s {
-    SCSI_MMC_DATA_READ,
-    SCSI_MMC_DATA_WRITE,
-    SCSI_MMC_DATA_NONE
-  } cdio_mmc_direction_t;
-  /**
-     Indicate to applications that \p SCSI_MMC_DATA_NONE is available.
-     It has been added after version 0.82 and should be used with
-     commands that neither read nor write payload bytes. (On
-     Linux, at least, these work with \p SCSI_MMC_DATA_READ and \p
-     SCSI_MMC_DATA_WRITE, too.)
-  */
+/**
+    An enumeration indicating whether an MMC command is sending
+    data, or getting data, both, or neither.
+*/
+typedef enum mmc_direction_s {
+  SCSI_MMC_DATA_READ,
+  SCSI_MMC_DATA_WRITE,
+  SCSI_MMC_DATA_NONE
+} cdio_mmc_direction_t;
+/**
+   Indicate to applications that \p SCSI_MMC_DATA_NONE is available.
+   It has been added after version 0.82 and should be used with
+   commands that neither read nor write payload bytes. (On
+   Linux, at least, these work with \p SCSI_MMC_DATA_READ and \p
+   SCSI_MMC_DATA_WRITE, too.)
+*/
 #define SCSI_MMC_HAS_DIR_NONE 1
 
-  typedef struct mmc_subchannel_s
-  {
-    uint8_t       reserved;
-    uint8_t       audio_status;
-    uint16_t      data_length; /**< Really ISO 9660 7.2.2 */
-    uint8_t       format;
-    uint8_t       address:      4;
-    uint8_t       control:      4;
-    uint8_t       track;
-    uint8_t       index;
-    uint8_t       abs_addr[4];
-    uint8_t       rel_addr[4];
-  } cdio_mmc_subchannel_t;
+typedef struct mmc_subchannel_s {
+  uint8_t reserved;
+  uint8_t audio_status;
+  uint16_t data_length; /**< Really ISO 9660 7.2.2 */
+  uint8_t format;
+  uint8_t address : 4;
+  uint8_t control : 4;
+  uint8_t track;
+  uint8_t index;
+  uint8_t abs_addr[4];
+  uint8_t rel_addr[4];
+} cdio_mmc_subchannel_t;
 
-#define CDIO_MMC_SET_COMMAND(cdb, command)      \
-  cdb[0] = command
+#define CDIO_MMC_SET_COMMAND(cdb, command) cdb[0] = command
 
-#define CDIO_MMC_SET_READ_TYPE(cdb, sector_type) \
-  cdb[1] = (sector_type << 2)
+#define CDIO_MMC_SET_READ_TYPE(cdb, sector_type) cdb[1] = (sector_type << 2)
 
-#define CDIO_MMC_GETPOS_LEN16(p, pos)           \
-  (p[pos]<<8) + p[pos+1]
+#define CDIO_MMC_GETPOS_LEN16(p, pos) (p[pos] << 8) + p[pos + 1]
 
-#define CDIO_MMC_GET_LEN16(p)                   \
-  (p[0]<<8) + p[1]
+#define CDIO_MMC_GET_LEN16(p) (p[0] << 8) + p[1]
 
-#define CDIO_MMC_GET_LEN32(p) \
-  (p[0] << 24) + (p[1] << 16) + (p[2] << 8) + p[3];
+#define CDIO_MMC_GET_LEN32(p) (p[0] << 24) + (p[1] << 16) + (p[2] << 8) + p[3];
 
-#define CDIO_MMC_SET_LEN16(cdb, pos, len)       \
-  cdb[pos  ] = (len >>  8) & 0xff;              \
-  cdb[pos+1] = (len      ) & 0xff
+#define CDIO_MMC_SET_LEN16(cdb, pos, len)                                      \
+  cdb[pos] = (len >> 8) & 0xff;                                                \
+  cdb[pos + 1] = (len) & 0xff
 
-#define CDIO_MMC_SET_READ_LBA(cdb, lba)         \
-  cdb[2] = (lba >> 24) & 0xff; \
-  cdb[3] = (lba >> 16) & 0xff; \
-  cdb[4] = (lba >>  8) & 0xff; \
-  cdb[5] = (lba      ) & 0xff
+#define CDIO_MMC_SET_READ_LBA(cdb, lba)                                        \
+  cdb[2] = (lba >> 24) & 0xff;                                                 \
+  cdb[3] = (lba >> 16) & 0xff;                                                 \
+  cdb[4] = (lba >> 8) & 0xff;                                                  \
+  cdb[5] = (lba) & 0xff
 
-#define CDIO_MMC_SET_START_TRACK(cdb, command) \
-  cdb[6] = command
+#define CDIO_MMC_SET_START_TRACK(cdb, command) cdb[6] = command
 
-#define CDIO_MMC_SET_READ_LENGTH24(cdb, len) \
-  cdb[6] = (len >> 16) & 0xff; \
-  cdb[7] = (len >>  8) & 0xff; \
-  cdb[8] = (len      ) & 0xff
+#define CDIO_MMC_SET_READ_LENGTH24(cdb, len)                                   \
+  cdb[6] = (len >> 16) & 0xff;                                                 \
+  cdb[7] = (len >> 8) & 0xff;                                                  \
+  cdb[8] = (len) & 0xff
 
 /* @deprecated Use CDIO_MMC_SET_LEN16 instead */
-#define CDIO_MMC_SET_READ_LENGTH16(cdb, len) \
-  CDIO_MMC_SET_LEN16(cdb, 7, len)
+#define CDIO_MMC_SET_READ_LENGTH16(cdb, len) CDIO_MMC_SET_LEN16(cdb, 7, len)
 
 /* @deprecated */
-#define CDIO_MMC_SET_READ_LENGTH8(cdb, len) \
-  cdb[8] = (len      ) & 0xff
+#define CDIO_MMC_SET_READ_LENGTH8(cdb, len) cdb[8] = (len) & 0xff
 
 #define CDIO_MMC_MCSB_ALL_HEADERS 0xf
 
-#define CDIO_MMC_SET_MAIN_CHANNEL_SELECTION_BITS(cdb, val) \
-  cdb[9] = val << 3;
+#define CDIO_MMC_SET_MAIN_CHANNEL_SELECTION_BITS(cdb, val) cdb[9] = val << 3;
 
 /**
    Get the output port volumes and port selections used on AUDIO PLAY
@@ -561,291 +544,318 @@ typedef struct mmc_cdb_s {
    @param p_volume volume parameters retrieved
    @return \p DRIVER_OP_SUCCESS if we ran the command ok.
 */
-driver_return_code_t mmc_audio_get_volume (CdIo_t *p_cdio,  /*out*/
-                                           mmc_audio_volume_t *p_volume);
+driver_return_code_t mmc_audio_get_volume(CdIo_t *p_cdio, /*out*/
+                                          mmc_audio_volume_t *p_volume);
 
-  /**
-     Read Audio Subchannel information
+/**
+   Read Audio Subchannel information
 
-     @param p_cdio the CD object to be acted upon.
-     @param p_subchannel place for returned subchannel information
-  */
-    driver_return_code_t
-    mmc_audio_read_subchannel (CdIo_t *p_cdio,
-                           /*out*/ cdio_subchannel_t *p_subchannel);
+   @param p_cdio the CD object to be acted upon.
+   @param p_subchannel place for returned subchannel information
+*/
+driver_return_code_t
+mmc_audio_read_subchannel(CdIo_t *p_cdio,
+                          /*out*/ cdio_subchannel_t *p_subchannel);
 
-  /**
-    Return a string containing the name of the audio state as returned from
-    the Q_SUBCHANNEL.
-  */
-  const char *mmc_audio_state2str( uint8_t i_audio_state );
+/**
+  Return a string containing the name of the audio state as returned from
+  the Q_SUBCHANNEL.
+*/
+const char *mmc_audio_state2str(uint8_t i_audio_state);
 
-  /**
-     Get the block size used in read requests, via MMC (e.g. READ_10,
-     READ_MSF, ...)
-     @param p_cdio the CD object to be acted upon.
-     @return the blocksize if > 0; error if <= 0
-  */
-  int mmc_get_blocksize ( CdIo_t *p_cdio );
+/**
+   Get the block size used in read requests, via MMC (e.g. READ_10,
+   READ_MSF, ...)
+   @param p_cdio the CD object to be acted upon.
+   @return the blocksize if > 0; error if <= 0
+*/
+int mmc_get_blocksize(CdIo_t *p_cdio);
 
-  /**
-    Return the length in bytes of the Command Descriptor
-    Buffer (CDB) for a given MMC command. The length will be
-    either 6, 10, or 12.
-  */
-  uint8_t mmc_get_cmd_len(uint8_t mmc_cmd);
+/**
+  Return the length in bytes of the Command Descriptor
+  Buffer (CDB) for a given MMC command. The length will be
+  either 6, 10, or 12.
+*/
+uint8_t mmc_get_cmd_len(uint8_t mmc_cmd);
 
-  /**
-    Get the lsn of the end of the CD
+/**
+  Get the lsn of the end of the CD
 
-    @param p_cdio the CD object to be acted upon.
-    @return the lsn. On error return CDIO_INVALID_LSN.
-  */
-  lsn_t mmc_get_disc_last_lsn( const CdIo_t *p_cdio );
+  @param p_cdio the CD object to be acted upon.
+  @return the lsn. On error return CDIO_INVALID_LSN.
+*/
+lsn_t mmc_get_disc_last_lsn(const CdIo_t *p_cdio);
 
-  /**
-    Return the discmode as reported by the MMC Read (FULL) \p TOC
-    command.
+/**
+  Return the discmode as reported by the MMC Read (FULL) \p TOC
+  command.
 
-    Information was obtained from Section 5.1.13 (Read TOC/PMA/ATIP)
-    pages 56-62 from the MMC draft specification, revision 10a
-    at http://www.t10.org/ftp/t10/drafts/mmc/mmc-r10a.pdf See
-    especially tables 72, 73 and 75.
-  */
-  discmode_t mmc_get_discmode( const CdIo_t *p_cdio );
+  Information was obtained from Section 5.1.13 (Read TOC/PMA/ATIP)
+  pages 56-62 from the MMC draft specification, revision 10a
+  at http://www.t10.org/ftp/t10/drafts/mmc/mmc-r10a.pdf See
+  especially tables 72, 73 and 75.
+*/
+discmode_t mmc_get_discmode(const CdIo_t *p_cdio);
 
+/**
+ * \brief Multimedia Commands (MMC) operational profile levels via INQUIRY
+(old).
+ *
+ * \deprecated This enum is deprecated and will be removed in the next major
+release.
+ *             Please use the new \ref cdio_mmc_inquiry_version_map or better
+ *             cdio_mmc_profile_t instead assessing capabilities of device.
+ */
+typedef enum {
+  CDIO_MMC_LEVEL_WEIRD,
+  CDIO_MMC_LEVEL_1,
+  CDIO_MMC_LEVEL_2,
+  CDIO_MMC_LEVEL_3,
+  CDIO_MMC_LEVEL_NONE
+} cdio_mmc_level_t;
 
-  /**
-    Get the MMC level supported by the device.
-    @param p_cdio the CD object to be acted upon.
-    @return MMC level supported by the device.
-  */
-  cdio_mmc_level_t mmc_get_drive_mmc_cap(CdIo_t *p_cdio);
-
-
-  /**
-    Get the DVD type associated with cd object.
-
-    @param p_cdio the CD object to be acted upon.
-    @param s location to store DVD information.
-    @return the DVD discmode.
-  */
-  discmode_t mmc_get_dvd_struct_physical ( const CdIo_t *p_cdio,
-                                           cdio_dvd_struct_t *s);
-
-  /**
-    Find out if media tray is open or closed.
-    @param p_cdio the CD object to be acted upon.
-    @return 1 if media is open, 0 if closed. Error
-    return codes are the same as \p driver_return_code_t.
-  */
-  int mmc_get_tray_status ( const CdIo_t *p_cdio );
-
-  /**
-    Get the CD-ROM hardware info via an MMC \p INQUIRY command.
-
-    @param p_cdio the CD object to be acted upon.
-    @param p_hw_info place to store hardware information retrieved
-    @return true if we were able to get hardware info, false if we had
-    an error.
-  */
-  bool mmc_get_hwinfo ( const CdIo_t *p_cdio,
-                        /* out*/ cdio_hwinfo_t *p_hw_info );
+/**
+  Get the MMC level supported by the device.
+  @param p_cdio the CD object to be acted upon.
+  @return MMC level supported by the device.
 
 
-  /**
-    Find out if media has changed since the last call.
-    @param p_cdio the CD object to be acted upon.
-    @return 1 if media has changed since last call, 0 if not. Error
-    return codes are the same as \p driver_return_code_t.
-  */
-  int mmc_get_media_changed(const CdIo_t *p_cdio);
+  \deprecated This enum is deprecated and will be removed in the next major
+release.
 
-  /**
-    Get the media catalog number (\p MCN) from the CD via MMC.
+*/
+cdio_mmc_level_t mmc_get_drive_mmc_cap(CdIo_t *p_cdio);
 
-    @param p_cdio the CD object to be acted upon.
-    @return the media catalog number or NULL if there is none, or we
-    can't get it.
+/**
+  Get the MMC level supported by the device using the SCSI INQUIRY command's
+  version field.
 
-    Note: The caller must free the returned string with cdio_free()
-    when done with it.
+  @param p_cdio the CD object to be acted upon.
+  @return MMC level supported by the device.
+*/
+cdio_mmc_inquiry_version_t mmc_get_drive_mmc_cap_from_inquiry_version(CdIo_t *p_cdio);
 
-  */
-  char * mmc_get_mcn(const CdIo_t *p_cdio);
+/**
+  Get the DVD type associated with cd object.
 
-  /**
-    Get the international standard recording code (\p ISRC) of the track via MMC.
+  @param p_cdio the CD object to be acted upon.
+  @param s location to store DVD information.
+  @return the DVD discmode.
+*/
+discmode_t mmc_get_dvd_struct_physical(const CdIo_t *p_cdio,
+                                       cdio_dvd_struct_t *s);
 
-    @param p_cdio the CD object to be acted upon.
-    @param i_track the track to get the ISRC info for
-    @return international standard recording code or NULL if there is
-    none or we can't get it.
+/**
+  Find out if media tray is open or closed.
+  @param p_cdio the CD object to be acted upon.
+  @return 1 if media is open, 0 if closed. Error
+  return codes are the same as \p driver_return_code_t.
+*/
+int mmc_get_tray_status(const CdIo_t *p_cdio);
 
-    Note: The caller must free the returned string with cdio_free()
-    when done with it.
+/**
+  Get the CD-ROM hardware info via an MMC \p INQUIRY command.
 
-  */
-  char * mmc_get_track_isrc(const CdIo_t *p_cdio, track_t i_track);
+  @param p_cdio the CD object to be acted upon.
+  @param p_hw_info place to store hardware information retrieved
+  @return true if we were able to get hardware info, false if we had
+  an error.
+*/
+bool mmc_get_hwinfo(const CdIo_t *p_cdio,
+                    /* out*/ cdio_hwinfo_t *p_hw_info);
 
-  /**
-    Read cdtext information for a cdtext_t object.
+/**
+  Find out if media has changed since the last call.
+  @param p_cdio the CD object to be acted upon.
+  @return 1 if media has changed since last call, 0 if not. Error
+  return codes are the same as \p driver_return_code_t.
+*/
+int mmc_get_media_changed(const CdIo_t *p_cdio);
 
-    This is the raw SCSI/MMC reply as retrieved by mmc_read_toc_cdtext().
-    It consists of 4 header bytes and a variable number of text packs.
+/**
+  Get the media catalog number (\p MCN) from the CD via MMC.
 
-    The first two bytes of the header, a Big-Endian number, specify
-    the number of following bytes. The count also includes the next two
-    header bytes, which should be 0.
+  @param p_cdio the CD object to be acted upon.
+  @return the media catalog number or NULL if there is none, or we
+  can't get it.
 
-    See also information in mmc_read_toc_cdtext().
+  Note: The caller must free the returned string with cdio_free()
+  when done with it.
 
-    Here is some code to parse the text packs into a \p cdtext_t object:
+*/
+char *mmc_get_mcn(const CdIo_t *p_cdio);
 
-    @code
-      #include <cdio/mmc.h>
-      #include <cdio/cdtext.h>
+/**
+  Get the international standard recording code (\p ISRC) of the track via MMC.
 
-      reply = mmc_read_cdtext(p_cdio);
-      if (NULL != reply)
-          cdtext_data_init(p_cdtext, reply + 4,
-                           (size_t) CDIO_MMC_GET_LEN16(reply) - 2);
-    @endcode
+  @param p_cdio the CD object to be acted upon.
+  @param i_track the track to get the ISRC info for
+  @return international standard recording code or NULL if there is
+  none or we can't get it.
 
-    @param p_cdio the CD object to be acted upon.
-    @return pointer to data on success, \p NULL on error or if CD-Text
-            information does not exist.
+  Note: The caller must free the returned string with cdio_free()
+  when done with it.
 
-    Note: the caller must free the returned memory.
+*/
+char *mmc_get_track_isrc(const CdIo_t *p_cdio, track_t i_track);
 
-  */
-  uint8_t * mmc_read_cdtext (const CdIo_t *p_cdio);
+/**
+  Read cdtext information for a cdtext_t object.
 
-  /**
-    Report if CD-ROM has a particular kind of interface (ATAPI, SCSCI, ...)
-    Is it possible for an interface to have several? If not, this
-    routine could probably return the single \p mmc_feature_interface_t.
-    @param p_cdio the CD object to be acted upon.
-    @param e_interface
-    @return true if we have the interface and false if not.
-  */
-  bool_3way_t mmc_have_interface(CdIo_t *p_cdio,
-                                 cdio_mmc_feature_interface_t e_interface );
+  This is the raw SCSI/MMC reply as retrieved by mmc_read_toc_cdtext().
+  It consists of 4 header bytes and a variable number of text packs.
 
+  The first two bytes of the header, a Big-Endian number, specify
+  the number of following bytes. The count also includes the next two
+  header bytes, which should be 0.
 
-  /**
-      Read just the user data part of some sort of data sector (via
-      mmc_read_cd).
+  See also information in mmc_read_toc_cdtext().
 
-      @param p_cdio object to read from
+  Here is some code to parse the text packs into a \p cdtext_t object:
 
-      @param p_buf place to read data into.  The caller should make
-             sure this location can store at least \p CDIO_CD_FRAMESIZE,
-             \p M2RAW_SECTOR_SIZE, or \p M2F2_SECTOR_SIZE depending on the
-             kind of sector getting read. If you don't know whether
-             you have a Mode 1/2, Form 1/ Form 2/Formless sector best
-             to reserve space for the maximum, \p M2RAW_SECTOR_SIZE.
+  @code
+    #include <cdio/cdtext.h>
+    #include <cdio/mmc.h>
 
-      @param i_lsn sector to read
-      @param i_blocksize size of each block
-      @param i_blocks number of blocks to read
+    reply = mmc_read_cdtext(p_cdio);
+    if (NULL != reply)
+        cdtext_data_init(p_cdtext, reply + 4,
+                         (size_t) CDIO_MMC_GET_LEN16(reply) - 2);
+  @endcode
 
-  */
-  driver_return_code_t mmc_read_data_sectors ( CdIo_t *p_cdio, void *p_buf,
-                                               lsn_t i_lsn,
-                                               uint16_t i_blocksize,
-                                               uint32_t i_blocks );
+  @param p_cdio the CD object to be acted upon.
+  @return pointer to data on success, \p NULL on error or if CD-Text
+          information does not exist.
 
-  /**
-      Read sectors using SCSI-MMC GPCMD_READ_CD.
-      Can read only up to 25 blocks.
-  */
-  driver_return_code_t mmc_read_sectors ( const CdIo_t *p_cdio, void *p_buf,
-                                          lsn_t i_lsn,  int read_sector_type,
-                                          uint32_t i_blocks);
+  Note: the caller must free the returned memory.
 
-  /**
-    Run a Multimedia command (MMC).
+*/
+uint8_t *mmc_read_cdtext(const CdIo_t *p_cdio);
 
-    @param p_cdio        CD structure set by cdio_open().
-    @param i_timeout_ms  time in milliseconds we will wait for the command
-                         to complete.
-    @param p_cdb         CDB bytes. All values that are needed should be set
-                         on input. We'll figure out what the right CDB length
-                         should be.
-    @param e_direction   direction the transfer is to go.
-    @param i_buf         Size of buffer
-    @param p_buf         Buffer for data, both sending and receiving.
+/**
+  Report if CD-ROM has a particular kind of interface (ATAPI, SCSCI, ...)
+  Is it possible for an interface to have several? If not, this
+  routine could probably return the single \p mmc_feature_interface_t.
+  @param p_cdio the CD object to be acted upon.
+  @param e_interface
+  @return true if we have the interface and false if not.
+*/
+bool_3way_t mmc_have_interface(CdIo_t *p_cdio,
+                               cdio_mmc_feature_interface_t e_interface);
 
-    @return 0 if command completed successfully.
-  */
-  driver_return_code_t
-  mmc_run_cmd( const CdIo_t *p_cdio, unsigned int i_timeout_ms,
-               const mmc_cdb_t *p_cdb,
-               cdio_mmc_direction_t e_direction, unsigned int i_buf,
-               /*in/out*/ void *p_buf );
+/**
+    Read just the user data part of some sort of data sector (via
+    mmc_read_cd).
 
-  /**
-    Run a Multimedia command (MMC) specifying the CDB length.
-    The motivation here is for example of use in is an undocumented
-    debug command for LG drives (namely E7), whose length is being
-    miscalculated by mmc_get_cmd_len(); it doesn't follow the usual
-    code number to length conventions. Patch supplied by SukkoPera.
+    @param p_cdio object to read from
 
-    @param p_cdio        CD structure set by cdio_open().
-    @param i_timeout_ms  time in milliseconds we will wait for the command
-                         to complete.
-    @param p_cdb         CDB bytes. All values that are needed should be set
-                         on input.
-    @param i_cdb         number of CDB bytes.
-    @param e_direction   direction the transfer is to go.
-    @param i_buf         Size of buffer
-    @param p_buf         Buffer for data, both sending and receiving.
+    @param p_buf place to read data into.  The caller should make
+           sure this location can store at least \p CDIO_CD_FRAMESIZE,
+           \p M2RAW_SECTOR_SIZE, or \p M2F2_SECTOR_SIZE depending on the
+           kind of sector getting read. If you don't know whether
+           you have a Mode 1/2, Form 1/ Form 2/Formless sector best
+           to reserve space for the maximum, \p M2RAW_SECTOR_SIZE.
 
-    @return 0 if command completed successfully.
-  */
-  driver_return_code_t
-  mmc_run_cmd_len( const CdIo_t *p_cdio, unsigned int i_timeout_ms,
-                   const mmc_cdb_t *p_cdb, unsigned int i_cdb,
-                   cdio_mmc_direction_t e_direction, unsigned int i_buf,
-                   /*in/out*/ void *p_buf );
+    @param i_lsn sector to read
+    @param i_blocksize size of each block
+    @param i_blocks number of blocks to read
 
-  /**
-      Obtain the SCSI sense reply of the most-recently-performed MMC command.
-      These bytes indicate possible problems which occurred in
-      the drive while the command was performed. With some commands they tell
-      about the current state of the drive (e.g. 00h \p TEST \p UNIT \p READY).
-      @param p_cdio CD structure set by cdio_open().
+*/
+driver_return_code_t mmc_read_data_sectors(CdIo_t *p_cdio, void *p_buf,
+                                           lsn_t i_lsn, uint16_t i_blocksize,
+                                           uint32_t i_blocks);
 
-      @param pp_sense returns the sense bytes received from the drive.
-      This is allocated memory or NULL if no sense bytes are
-      available. Dispose non-NULL pointers by cdio_free() when no longer
-      needed.  See SPC-3 4.5.3 Fixed format sense data.  SCSI error
-      codes as of SPC-3 Annex D, MMC-5 Annex F: sense[2]&15 = Key ,
-      sense[12] = \p ASC , sense[13] = \p ASCQ
+/**
+    Read sectors using SCSI-MMC GPCMD_READ_CD.
+    Can read only up to 25 blocks.
+*/
+driver_return_code_t mmc_read_sectors(const CdIo_t *p_cdio, void *p_buf,
+                                      lsn_t i_lsn, int read_sector_type,
+                                      uint32_t i_blocks);
 
-      @return number of valid bytes in sense, 0 when no sense
-              bytes are available, and less than 0 when there is an internal error.
-  */
-  int mmc_last_cmd_sense ( const CdIo_t *p_cdio,
-                           cdio_mmc_request_sense_t **pp_sense);
+/**
+  Run a Multimedia command (MMC).
 
-  /**
-    Set the block size for subsequent read requests, via MMC.
-  */
-  driver_return_code_t mmc_set_blocksize ( const CdIo_t *p_cdio,
-                                           uint16_t i_blocksize);
+  @param p_cdio        CD structure set by cdio_open().
+  @param i_timeout_ms  time in milliseconds we will wait for the command
+                       to complete.
+  @param p_cdb         CDB bytes. All values that are needed should be set
+                       on input. We'll figure out what the right CDB length
+                       should be.
+  @param e_direction   direction the transfer is to go.
+  @param i_buf         Size of buffer
+  @param p_buf         Buffer for data, both sending and receiving.
 
-  /**
-    Get string name for MMC command
+  @return 0 if command completed successfully.
+*/
+driver_return_code_t mmc_run_cmd(const CdIo_t *p_cdio,
+                                 unsigned int i_timeout_ms,
+                                 const mmc_cdb_t *p_cdb,
+                                 cdio_mmc_direction_t e_direction,
+                                 unsigned int i_buf,
+                                 /*in/out*/ void *p_buf);
 
-    @param command cdio_mmc_gpcmd_t command value
-    @return string name of command
+/**
+  Run a Multimedia command (MMC) specifying the CDB length.
+  The motivation here is for example of use in is an undocumented
+  debug command for LG drives (namely E7), whose length is being
+  miscalculated by mmc_get_cmd_len(); it doesn't follow the usual
+  code number to length conventions. Patch supplied by SukkoPera.
 
-  */
-  const char *mmc_cmd2str(uint8_t command);
+  @param p_cdio        CD structure set by cdio_open().
+  @param i_timeout_ms  time in milliseconds we will wait for the command
+                       to complete.
+  @param p_cdb         CDB bytes. All values that are needed should be set
+                       on input.
+  @param i_cdb         number of CDB bytes.
+  @param e_direction   direction the transfer is to go.
+  @param i_buf         Size of buffer
+  @param p_buf         Buffer for data, both sending and receiving.
 
+  @return 0 if command completed successfully.
+*/
+driver_return_code_t mmc_run_cmd_len(const CdIo_t *p_cdio,
+                                     unsigned int i_timeout_ms,
+                                     const mmc_cdb_t *p_cdb, unsigned int i_cdb,
+                                     cdio_mmc_direction_t e_direction,
+                                     unsigned int i_buf,
+                                     /*in/out*/ void *p_buf);
 
+/**
+    Obtain the SCSI sense reply of the most-recently-performed MMC command.
+    These bytes indicate possible problems which occurred in
+    the drive while the command was performed. With some commands they tell
+    about the current state of the drive (e.g. 00h \p TEST \p UNIT \p READY).
+    @param p_cdio CD structure set by cdio_open().
+
+    @param pp_sense returns the sense bytes received from the drive.
+    This is allocated memory or NULL if no sense bytes are
+    available. Dispose non-NULL pointers by cdio_free() when no longer
+    needed.  See SPC-3 4.5.3 Fixed format sense data.  SCSI error
+    codes as of SPC-3 Annex D, MMC-5 Annex F: sense[2]&15 = Key ,
+    sense[12] = \p ASC , sense[13] = \p ASCQ
+
+    @return number of valid bytes in sense, 0 when no sense
+            bytes are available, and less than 0 when there is an internal
+   error.
+*/
+int mmc_last_cmd_sense(const CdIo_t *p_cdio,
+                       cdio_mmc_request_sense_t **pp_sense);
+
+/**
+  Set the block size for subsequent read requests, via MMC.
+*/
+driver_return_code_t mmc_set_blocksize(const CdIo_t *p_cdio,
+                                       uint16_t i_blocksize);
+
+/**
+  Get string name for MMC command
+
+  @param command cdio_mmc_gpcmd_t command value
+  @return string name of command
+
+*/
+const char *mmc_cmd2str(uint8_t command);
 
 #ifdef __cplusplus
 }
@@ -857,24 +867,24 @@ driver_return_code_t mmc_audio_get_volume (CdIo_t *p_cdio,  /*out*/
     allow one to refer to the enumeration value names in the typedefs
     above in a debugger and debugger expressions
 */
-extern cdio_mmc_feature_t           debug_cdio_mmc_feature;
+extern cdio_mmc_feature_t debug_cdio_mmc_feature;
 extern cdio_mmc_feature_interface_t debug_cdio_mmc_feature_interface;
-extern cdio_mmc_feature_profile_t   debug_cdio_mmc_feature_profile;
-extern cdio_mmc_get_conf_t          debug_cdio_mmc_get_conf;
-extern cdio_mmc_gpcmd_t             debug_cdio_mmc_gpcmd;
-extern cdio_mmc_read_sub_state_t    debug_cdio_mmc_read_sub_state;
-extern cdio_mmc_read_cd_type_t      debug_cdio_mmc_read_cd_type;
-extern cdio_mmc_readtoc_t           debug_cdio_mmc_readtoc;
-extern cdio_mmc_mode_page_t         debug_cdio_mmc_mode_page;
+extern cdio_mmc_feature_profile_t debug_cdio_mmc_feature_profile;
+extern cdio_mmc_get_conf_t debug_cdio_mmc_get_conf;
+extern cdio_mmc_gpcmd_t debug_cdio_mmc_gpcmd;
+extern cdio_mmc_read_sub_state_t debug_cdio_mmc_read_sub_state;
+extern cdio_mmc_read_cd_type_t debug_cdio_mmc_read_cd_type;
+extern cdio_mmc_readtoc_t debug_cdio_mmc_readtoc;
+extern cdio_mmc_mode_page_t debug_cdio_mmc_mode_page;
 
 #ifndef DO_NOT_WANT_OLD_MMC_COMPATIBILITY
 #define CDIO_MMC_GPCMD_START_STOP CDIO_MMC_GPCMD_START_STOP_UNIT
-#define CDIO_MMC_GPCMD_ALLOW_MEDIUM_REMOVAL  \
-    CDIO_MMC_GPCMD_PREVENT_ALLOW_MEDIUM_REMOVAL
+#define CDIO_MMC_GPCMD_ALLOW_MEDIUM_REMOVAL                                    \
+  CDIO_MMC_GPCMD_PREVENT_ALLOW_MEDIUM_REMOVAL
 #endif /*DO_NOT_WANT_PARANOIA_COMPATIBILITY*/
 
 #endif /* CDIO_MMC_H_ */
-
+
 /*
  * Local variables:
  *  c-file-style: "ruby"

--- a/include/cdio/mmc_util.h
+++ b/include/cdio/mmc_util.h
@@ -31,131 +31,135 @@
 extern "C" {
 #endif /* __cplusplus */
 
-  /* MMC Version to SCSI/SPC Mapping. This is used in the INQUIRY command.
-   */
-  typedef enum {
-    CDIO_MMC_LEVEL_WEIRD,
-    CDIO_MMC_LEVEL_1 = 0x2, /* SCSI-2 */
-    CDIO_MMC_LEVEL_1a = 0x3, /* SPC-1 / ANSI X3.301-1997 */
-    CDIO_MMC_LEVEL_2 = 0x4, /* SPC-2 / ANSI INCITS 351-200 */
-    CDIO_MMC_LEVEL_3 = 0x5, /* SPC-3 / ANSI INCITS 408-2005 */
-    CDIO_MMC_LEVEL_45 = 0x6, /* SPC-4/5 */
-    CDIO_MMC_LEVEL_5 = 0x7, /* SPC-5 / MMC-5/6 */
-    CDIO_MMC_LEVEL_NONE
-  } cdio_mmc_level_t;
+/**
+ * \brief MMC INQUIRY Version to SCSI/SPC Mapping.
+ *
+ * This is used in the INQUIRY command.  Consider cdio_mmc_profile_t
+ * instead a better way to get the capabilities of a device.
+ */
+typedef enum {
+  CDIO_INQUIRY_VERSION_WEIRD,
+  CDIO_INQUIRY_VERSION_1 = 0x2,  /* SCSI-2 */
+  CDIO_INQUIRY_VERSION_1a = 0x3, /* SPC-1 / ANSI X3.301-1997 */
+  CDIO_INQUIRY_VERSION_2 = 0x4,  /* SPC-2 / ANSI INCITS 351-200 */
+  CDIO_INQUIRY_VERSION_3 = 0x5,  /* SPC-3 / ANSI INCITS 408-2005 */
+  CDIO_INQUIRY_VERSION_45 = 0x6, /* SPC-4/5 */
+  CDIO_INQUIRY_VERSION_5 = 0x7,  /* SPC-5 / MMC-5/6 */
+  CDIO_INQUIRY_VERSION_NONE
+} cdio_mmc_inquiry_version_t;
 
-    /**
-       Profile profile codes used in GET_CONFIGURATION - PROFILE LIST. */
-    typedef enum {
-        CDIO_MMC_FEATURE_PROF_NON_REMOVABLE = 0x0001, /**< Re-writable disc, capable
-                                                         of changing behavior */
-        CDIO_MMC_FEATURE_PROF_REMOVABLE     = 0x0002, /**< disk Re-writable; with
-                                                         removable  media */
-        CDIO_MMC_FEATURE_PROF_MO_ERASABLE   = 0x0003, /**< Erasable Magneto-Optical
-                                                         disk with sector erase
-                                                         capability */
-        CDIO_MMC_FEATURE_PROF_MO_WRITE_ONCE = 0x0004, /**< Write Once Magneto-Optical
-                                                         write once */
-        CDIO_MMC_FEATURE_PROF_AS_MO         = 0x0005, /**< Advance Storage
-                                                         Magneto-Optical */
-        CDIO_MMC_FEATURE_PROF_CD_ROM        = 0x0008, /**< Read only Compact Disc
-                                                         capable */
-        CDIO_MMC_FEATURE_PROF_CD_R          = 0x0009, /**< Write once Compact Disc
-                                                         capable */
-        CDIO_MMC_FEATURE_PROF_CD_RW         = 0x000A, /**< CD-RW Re-writable
-                                                         Compact Disc capable */
+/**
+   Profile profile codes used in GET_CONFIGURATION - PROFILE LIST. */
+typedef enum {
+  CDIO_MMC_FEATURE_PROF_NON_REMOVABLE = 0x0001, /**< Re-writable disc, capable
+                                                   of changing behavior */
+  CDIO_MMC_FEATURE_PROF_REMOVABLE = 0x0002,     /**< disk Re-writable; with
+                                                   removable  media */
+  CDIO_MMC_FEATURE_PROF_MO_ERASABLE = 0x0003,   /**< Erasable Magneto-Optical
+                                                   disk with sector erase
+                                                   capability */
+  CDIO_MMC_FEATURE_PROF_MO_WRITE_ONCE = 0x0004, /**< Write Once Magneto-Optical
+                                                   write once */
+  CDIO_MMC_FEATURE_PROF_AS_MO = 0x0005,         /**< Advance Storage
+                                                   Magneto-Optical */
+  CDIO_MMC_FEATURE_PROF_CD_ROM = 0x0008,        /**< Read only Compact Disc
+                                                   capable */
+  CDIO_MMC_FEATURE_PROF_CD_R = 0x0009,          /**< Write once Compact Disc
+                                                   capable */
+  CDIO_MMC_FEATURE_PROF_CD_RW = 0x000A,         /**< CD-RW Re-writable
+                                                   Compact Disc capable */
 
-        CDIO_MMC_FEATURE_PROF_DVD_ROM       = 0x0010, /**< Read only DVD */
-        CDIO_MMC_FEATURE_PROF_DVD_R_SEQ     = 0x0011, /**< Re-recordable DVD using
-                                                         Sequential recording */
-        CDIO_MMC_FEATURE_PROF_DVD_RAM       = 0x0012, /**< Re-writable DVD */
-        CDIO_MMC_FEATURE_PROF_DVD_RW_RO     = 0x0013, /**< Re-recordable DVD using
-                                                         Restricted Overwrite */
-        CDIO_MMC_FEATURE_PROF_DVD_RW_SEQ    = 0x0014, /**< Re-recordable DVD using
-                                                         Sequential recording */
-        CDIO_MMC_FEATURE_PROF_DVD_R_DL_SEQ  = 0x0015, /**< DVD-R/DL sequential
-                                                         recording */
-        CDIO_MMC_FEATURE_PROF_DVD_R_DL_JR   = 0x0016, /**< DVD-R/DL layer jump
-                                                         recording */
-        CDIO_MMC_FEATURE_PROF_DVD_PRW       = 0x001A, /**< DVD+RW - DVD ReWritable */
-        CDIO_MMC_FEATURE_PROF_DVD_PR        = 0x001B, /**< DVD+R - DVD Recordable */
-        CDIO_MMC_FEATURE_PROF_DDCD_ROM      = 0x0020, /**< Read only  DDCD */
-        CDIO_MMC_FEATURE_PROF_DDCD_R        = 0x0021, /**< DDCD-R Write only DDCD */
-        CDIO_MMC_FEATURE_PROF_DDCD_RW       = 0x0022, /**< Re-Write only DDCD */
-        CDIO_MMC_FEATURE_PROF_DVD_PRW_DL    = 0x002A, /**< "DVD+RW/DL */
-        CDIO_MMC_FEATURE_PROF_DVD_PR_DL     = 0x002B, /**< DVD+R - DVD Recordable
-                                                         double layer */
+  CDIO_MMC_FEATURE_PROF_DVD_ROM = 0x0010,      /**< Read only DVD */
+  CDIO_MMC_FEATURE_PROF_DVD_R_SEQ = 0x0011,    /**< Re-recordable DVD using
+                                                  Sequential recording */
+  CDIO_MMC_FEATURE_PROF_DVD_RAM = 0x0012,      /**< Re-writable DVD */
+  CDIO_MMC_FEATURE_PROF_DVD_RW_RO = 0x0013,    /**< Re-recordable DVD using
+                                                  Restricted Overwrite */
+  CDIO_MMC_FEATURE_PROF_DVD_RW_SEQ = 0x0014,   /**< Re-recordable DVD using
+                                                  Sequential recording */
+  CDIO_MMC_FEATURE_PROF_DVD_R_DL_SEQ = 0x0015, /**< DVD-R/DL sequential
+                                                  recording */
+  CDIO_MMC_FEATURE_PROF_DVD_R_DL_JR = 0x0016,  /**< DVD-R/DL layer jump
+                                                  recording */
+  CDIO_MMC_FEATURE_PROF_DVD_PRW = 0x001A,      /**< DVD+RW - DVD ReWritable */
+  CDIO_MMC_FEATURE_PROF_DVD_PR = 0x001B,       /**< DVD+R - DVD Recordable */
+  CDIO_MMC_FEATURE_PROF_DDCD_ROM = 0x0020,     /**< Read only  DDCD */
+  CDIO_MMC_FEATURE_PROF_DDCD_R = 0x0021,       /**< DDCD-R Write only DDCD */
+  CDIO_MMC_FEATURE_PROF_DDCD_RW = 0x0022,      /**< Re-Write only DDCD */
+  CDIO_MMC_FEATURE_PROF_DVD_PRW_DL = 0x002A,   /**< "DVD+RW/DL */
+  CDIO_MMC_FEATURE_PROF_DVD_PR_DL = 0x002B,    /**< DVD+R - DVD Recordable
+                                                  double layer */
 
-        CDIO_MMC_FEATURE_PROF_BD_ROM        = 0x0040, /**< BD-ROM */
-        CDIO_MMC_FEATURE_PROF_BD_SEQ        = 0x0041, /**< BD-R sequential
-                                                         recording */
-        CDIO_MMC_FEATURE_PROF_BD_R_RANDOM   = 0x0042, /**< BD-R random recording */
-        CDIO_MMC_FEATURE_PROF_BD_RE         = 0x0043, /**< BD-RE */
+  CDIO_MMC_FEATURE_PROF_BD_ROM = 0x0040,      /**< BD-ROM */
+  CDIO_MMC_FEATURE_PROF_BD_SEQ = 0x0041,      /**< BD-R sequential
+                                                 recording */
+  CDIO_MMC_FEATURE_PROF_BD_R_RANDOM = 0x0042, /**< BD-R random recording */
+  CDIO_MMC_FEATURE_PROF_BD_RE = 0x0043,       /**< BD-RE */
 
-        CDIO_MMC_FEATURE_PROF_HD_DVD_ROM    = 0x0050, /**< HD-DVD-ROM */
-        CDIO_MMC_FEATURE_PROF_HD_DVD_R      = 0x0051, /**< HD-DVD-R */
-        CDIO_MMC_FEATURE_PROF_HD_DVD_RAM    = 0x0052, /**<"HD-DVD-RAM */
+  CDIO_MMC_FEATURE_PROF_HD_DVD_ROM = 0x0050, /**< HD-DVD-ROM */
+  CDIO_MMC_FEATURE_PROF_HD_DVD_R = 0x0051,   /**< HD-DVD-R */
+  CDIO_MMC_FEATURE_PROF_HD_DVD_RAM = 0x0052, /**<"HD-DVD-RAM */
 
-        CDIO_MMC_FEATURE_PROF_NON_CONFORM   = 0xFFFF, /**< The Logical Unit does not
-                                                         conform to any Profile. */
-    } cdio_mmc_feature_profile_t;
+  CDIO_MMC_FEATURE_PROF_NON_CONFORM = 0xFFFF, /**< The Logical Unit does not
+                                                 conform to any Profile. */
+} cdio_mmc_feature_profile_t;
 
-    /**
-       @param i_feature MMC feature number
-       @return string containing the name of the given feature
-    */
-    const char *mmc_feature2str( int i_feature );
+/**
+   @param i_feature MMC feature number
+   @return string containing the name of the given feature
+*/
+const char *mmc_feature2str(int i_feature);
 
-    /**
-       Get drive capabilities for a device.
-       @param p_cdio the CD object to be acted upon.
-       @param p_read_cap  list of read capabilities that are set on return
-       @param p_write_cap list of write capabilities that are set on return
-       @param p_misc_cap  list of miscellaneous capabilities (that are neither
-       read nor write related) that are set on return
-       @return the drive MMC capability level
-    */
-    void mmc_get_drive_cap ( CdIo_t *p_cdio,
-                             /*out*/ cdio_drive_read_cap_t  *p_read_cap,
-                             /*out*/ cdio_drive_write_cap_t *p_write_cap,
-                             /*out*/ cdio_drive_misc_cap_t  *p_misc_cap);
+/**
+   Get drive capabilities for a device.
+   @param p_cdio the CD object to be acted upon.
+   @param p_read_cap  list of read capabilities that are set on return
+   @param p_write_cap list of write capabilities that are set on return
+   @param p_misc_cap  list of miscellaneous capabilities (that are neither
+   read nor write related) that are set on return
+   @return the drive MMC capability level
+*/
+void mmc_get_drive_cap(CdIo_t *p_cdio,
+                       /*out*/ cdio_drive_read_cap_t *p_read_cap,
+                       /*out*/ cdio_drive_write_cap_t *p_write_cap,
+                       /*out*/ cdio_drive_misc_cap_t *p_misc_cap);
 
-    /**
-       Return a string containing the name of the given feature
-    */
-    const char *mmc_feature_profile2str( int i_feature_profile );
+/**
+   Return a string containing the name of the given feature
+*/
+const char *mmc_feature_profile2str(int i_feature_profile);
 
-    bool mmc_is_disctype_bd(cdio_mmc_feature_profile_t disctype);
-    bool mmc_is_disctype_cdrom(cdio_mmc_feature_profile_t disctype);
-    bool mmc_is_disctype_dvd(cdio_mmc_feature_profile_t disctype);
-    bool mmc_is_disctype_hd_dvd (cdio_mmc_feature_profile_t disctype);
-    bool mmc_is_disctype_overwritable (cdio_mmc_feature_profile_t disctype);
-    bool mmc_is_disctype_rewritable(cdio_mmc_feature_profile_t disctype);
+bool mmc_is_disctype_bd(cdio_mmc_feature_profile_t disctype);
+bool mmc_is_disctype_cdrom(cdio_mmc_feature_profile_t disctype);
+bool mmc_is_disctype_dvd(cdio_mmc_feature_profile_t disctype);
+bool mmc_is_disctype_hd_dvd(cdio_mmc_feature_profile_t disctype);
+bool mmc_is_disctype_overwritable(cdio_mmc_feature_profile_t disctype);
+bool mmc_is_disctype_rewritable(cdio_mmc_feature_profile_t disctype);
 
-    /** The default read timeout is 3 minutes. */
-#define MMC_READ_TIMEOUT_DEFAULT 3*60*1000
+/** The default read timeout is 3 minutes. */
+#define MMC_READ_TIMEOUT_DEFAULT 3 * 60 * 1000
 
-    /**
-       Set this to the maximum value in milliseconds that we will
-       wait on an MMC read command.
-    */
-    extern uint32_t mmc_read_timeout_ms;
+/**
+   Set this to the maximum value in milliseconds that we will
+   wait on an MMC read command.
+*/
+extern uint32_t mmc_read_timeout_ms;
 
-    /**
-       Maps a mmc_sense_key_t into a string name.
-    */
-    extern const char mmc_sense_key2str[16][40];
+/**
+   Maps a mmc_sense_key_t into a string name.
+*/
+extern const char mmc_sense_key2str[16][40];
 
-    /**
-       The default timeout (non-read) is 6 seconds.
-    */
+/**
+   The default timeout (non-read) is 6 seconds.
+*/
 #define MMC_TIMEOUT_DEFAULT 6000
 
-    /**
-       Set this to the maximum value in milliseconds that we will
-       wait on an MMC command.
-    */
-    extern uint32_t mmc_timeout_ms;
+/**
+   Set this to the maximum value in milliseconds that we will
+   wait on an MMC command.
+*/
+extern uint32_t mmc_timeout_ms;
 
 #ifdef __cplusplus
 }

--- a/include/cdio/mmc_util.h
+++ b/include/cdio/mmc_util.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2010, 2012 Rocky Bernstein <rocky@gnu.org>
+    Copyright (C) 2010, 2012, 2026 Rocky Bernstein <rocky@gnu.org>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -16,8 +16,8 @@
 */
 
 /**
-   \file mmc_util.h 
-   
+   \file mmc_util.h
+
    \brief Multimedia Command (MMC) "helper" routines that don't depend
    on anything other than headers.
 */
@@ -31,12 +31,25 @@
 extern "C" {
 #endif /* __cplusplus */
 
+  /* MMC Version to SCSI/SPC Mapping. This is used in the INQUIRY command.
+   */
+  typedef enum {
+    CDIO_MMC_LEVEL_WEIRD,
+    CDIO_MMC_LEVEL_1 = 0x2, /* SCSI-2 */
+    CDIO_MMC_LEVEL_1a = 0x3, /* SPC-1 / ANSI X3.301-1997 */
+    CDIO_MMC_LEVEL_2 = 0x4, /* SPC-2 / ANSI INCITS 351-200 */
+    CDIO_MMC_LEVEL_3 = 0x5, /* SPC-3 / ANSI INCITS 408-2005 */
+    CDIO_MMC_LEVEL_45 = 0x6, /* SPC-4/5 */
+    CDIO_MMC_LEVEL_5 = 0x7, /* SPC-5 / MMC-5/6 */
+    CDIO_MMC_LEVEL_NONE
+  } cdio_mmc_level_t;
+
     /**
        Profile profile codes used in GET_CONFIGURATION - PROFILE LIST. */
     typedef enum {
         CDIO_MMC_FEATURE_PROF_NON_REMOVABLE = 0x0001, /**< Re-writable disc, capable
                                                          of changing behavior */
-        CDIO_MMC_FEATURE_PROF_REMOVABLE     = 0x0002, /**< disk Re-writable; with 
+        CDIO_MMC_FEATURE_PROF_REMOVABLE     = 0x0002, /**< disk Re-writable; with
                                                          removable  media */
         CDIO_MMC_FEATURE_PROF_MO_ERASABLE   = 0x0003, /**< Erasable Magneto-Optical
                                                          disk with sector erase
@@ -51,7 +64,7 @@ extern "C" {
                                                          capable */
         CDIO_MMC_FEATURE_PROF_CD_RW         = 0x000A, /**< CD-RW Re-writable
                                                          Compact Disc capable */
-        
+
         CDIO_MMC_FEATURE_PROF_DVD_ROM       = 0x0010, /**< Read only DVD */
         CDIO_MMC_FEATURE_PROF_DVD_R_SEQ     = 0x0011, /**< Re-recordable DVD using
                                                          Sequential recording */
@@ -62,7 +75,7 @@ extern "C" {
                                                          Sequential recording */
         CDIO_MMC_FEATURE_PROF_DVD_R_DL_SEQ  = 0x0015, /**< DVD-R/DL sequential
                                                          recording */
-        CDIO_MMC_FEATURE_PROF_DVD_R_DL_JR   = 0x0016, /**< DVD-R/DL layer jump 
+        CDIO_MMC_FEATURE_PROF_DVD_R_DL_JR   = 0x0016, /**< DVD-R/DL layer jump
                                                          recording */
         CDIO_MMC_FEATURE_PROF_DVD_PRW       = 0x001A, /**< DVD+RW - DVD ReWritable */
         CDIO_MMC_FEATURE_PROF_DVD_PR        = 0x001B, /**< DVD+R - DVD Recordable */
@@ -70,29 +83,29 @@ extern "C" {
         CDIO_MMC_FEATURE_PROF_DDCD_R        = 0x0021, /**< DDCD-R Write only DDCD */
         CDIO_MMC_FEATURE_PROF_DDCD_RW       = 0x0022, /**< Re-Write only DDCD */
         CDIO_MMC_FEATURE_PROF_DVD_PRW_DL    = 0x002A, /**< "DVD+RW/DL */
-        CDIO_MMC_FEATURE_PROF_DVD_PR_DL     = 0x002B, /**< DVD+R - DVD Recordable 
+        CDIO_MMC_FEATURE_PROF_DVD_PR_DL     = 0x002B, /**< DVD+R - DVD Recordable
                                                          double layer */
-        
+
         CDIO_MMC_FEATURE_PROF_BD_ROM        = 0x0040, /**< BD-ROM */
-        CDIO_MMC_FEATURE_PROF_BD_SEQ        = 0x0041, /**< BD-R sequential 
+        CDIO_MMC_FEATURE_PROF_BD_SEQ        = 0x0041, /**< BD-R sequential
                                                          recording */
         CDIO_MMC_FEATURE_PROF_BD_R_RANDOM   = 0x0042, /**< BD-R random recording */
         CDIO_MMC_FEATURE_PROF_BD_RE         = 0x0043, /**< BD-RE */
-        
+
         CDIO_MMC_FEATURE_PROF_HD_DVD_ROM    = 0x0050, /**< HD-DVD-ROM */
         CDIO_MMC_FEATURE_PROF_HD_DVD_R      = 0x0051, /**< HD-DVD-R */
         CDIO_MMC_FEATURE_PROF_HD_DVD_RAM    = 0x0052, /**<"HD-DVD-RAM */
-        
+
         CDIO_MMC_FEATURE_PROF_NON_CONFORM   = 0xFFFF, /**< The Logical Unit does not
                                                          conform to any Profile. */
     } cdio_mmc_feature_profile_t;
-  
+
     /**
        @param i_feature MMC feature number
        @return string containing the name of the given feature
     */
     const char *mmc_feature2str( int i_feature );
-    
+
     /**
        Get drive capabilities for a device.
        @param p_cdio the CD object to be acted upon.
@@ -100,12 +113,13 @@ extern "C" {
        @param p_write_cap list of write capabilities that are set on return
        @param p_misc_cap  list of miscellaneous capabilities (that are neither
        read nor write related) that are set on return
+       @return the drive MMC capability level
     */
     void mmc_get_drive_cap ( CdIo_t *p_cdio,
                              /*out*/ cdio_drive_read_cap_t  *p_read_cap,
                              /*out*/ cdio_drive_write_cap_t *p_write_cap,
                              /*out*/ cdio_drive_misc_cap_t  *p_misc_cap);
-    
+
     /**
        Return a string containing the name of the given feature
     */
@@ -117,38 +131,38 @@ extern "C" {
     bool mmc_is_disctype_hd_dvd (cdio_mmc_feature_profile_t disctype);
     bool mmc_is_disctype_overwritable (cdio_mmc_feature_profile_t disctype);
     bool mmc_is_disctype_rewritable(cdio_mmc_feature_profile_t disctype);
-    
+
     /** The default read timeout is 3 minutes. */
 #define MMC_READ_TIMEOUT_DEFAULT 3*60*1000
-    
+
     /**
        Set this to the maximum value in milliseconds that we will
-       wait on an MMC read command.  
+       wait on an MMC read command.
     */
     extern uint32_t mmc_read_timeout_ms;
-    
+
     /**
        Maps a mmc_sense_key_t into a string name.
     */
     extern const char mmc_sense_key2str[16][40];
 
     /**
-       The default timeout (non-read) is 6 seconds. 
+       The default timeout (non-read) is 6 seconds.
     */
 #define MMC_TIMEOUT_DEFAULT 6000
 
     /**
        Set this to the maximum value in milliseconds that we will
-       wait on an MMC command.  
+       wait on an MMC command.
     */
-    extern uint32_t mmc_timeout_ms; 
+    extern uint32_t mmc_timeout_ms;
 
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
 
 #endif /* CDIO_MMC_UTIL_H_ */
-/* 
+/*
  * Local variables:
  *  c-file-style: "gnu"
  *  tab-width: 8

--- a/lib/driver/libcdio.sym
+++ b/lib/driver/libcdio.sym
@@ -214,6 +214,7 @@ mmc_get_configuration
 mmc_get_discmode
 mmc_get_disctype
 mmc_get_disc_erasable
+mmc_get_drive_mmc_cap_from_inquiry_version
 mmc_get_drive_mmc_cap
 mmc_get_dvd_struct_physical
 mmc_get_event_status

--- a/lib/driver/libcdio.sym
+++ b/lib/driver/libcdio.sym
@@ -214,7 +214,7 @@ mmc_get_configuration
 mmc_get_discmode
 mmc_get_disctype
 mmc_get_disc_erasable
-mmc_get_drive_mmc_cap_from_inquiry_version
+mmc_get_INQUIRY_version
 mmc_get_drive_mmc_cap
 mmc_get_dvd_struct_physical
 mmc_get_event_status

--- a/lib/driver/mmc/mmc.c
+++ b/lib/driver/mmc/mmc.c
@@ -831,90 +831,11 @@ mmc_get_drive_cap (CdIo_t *p_cdio,
   return;
 }
 
-/* Helper: issue plain SCSI INQUIRY (CDIO_MMC_GPCMD_INQUIRY), EVPD = 0
-   (standard). Fills buf up to buf_len and returns 0 on success or negative on
-   error.
-*/
-static int mmc_issue_inquiry(CdIo_t *p_cdio, uint8_t *buf, uint8_t buf_len) {
-  mmc_cdb_t cdb = {.field = {
-       CDIO_MMC_GPCMD_INQUIRY, 0x00, /* EVPD = 0, standard INQUIRY */
-       0x00, /* Page code (unused when EVPD=0) */
-       0x00, /* MSB allocation length is 0. */
-       0x00, buf_len, /* LSB allocation length */
-       0x00  /* Control */
-    }};
-  int i_status;
-
-  if (!p_cdio)
-    return -1;
-
-  CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_INQUIRY);
-
-  i_status = mmc_run_cmd(p_cdio, mmc_timeout_ms, &cdb, SCSI_MMC_DATA_READ,
-                         sizeof(buf), &buf);
-  return i_status;
-}
 /**
    Get drive capabilities for a device.
    @param p_cdio the CD object to be acted upon.
    @return the drive capabilities.
 */
-
-/* Size we request from INQUIRY: large enough to include version descriptors.
-   Note: this should be less than 256 so the number fits in one byte.
- */
-#define MMC_INQUIRY_ALLOC 252
-
-/**
-   Get the MMC level supported by the device via INQUIRY and the Version field..
-
-   Parse INQUIRY Version and search for version descriptors indicating
-   MMC support. Returns CDIO_INQUIRY_VERSION_* or CDIO_INQUIRY_VERSION_NONE on transport
-   failure.
-*/
-cdio_mmc_inquiry_version_t mmc_get_drive_mmc_cap_from_inquiry_version(CdIo_t *p_cdio)
-{
-  /* Largest buffer size we use. */
-  uint8_t buf[MMC_INQUIRY_ALLOC];
-  uint8_t scsi_version;
-  int rc = mmc_issue_inquiry(p_cdio, buf, sizeof(buf));
-  size_t additional_len = (size_t)buf[4];
-  size_t total_len = 5 + additional_len;
-
-  if (rc != 0) {
-    /* transport failure */
-    return CDIO_INQUIRY_VERSION_NONE;
-  }
-
-  /* Basic sanity checks: minimum INQUIRY length is 36 bytes (standard) */
-  if (buf[4] < 31) {
-    /* additional length field too small to contain version descriptors */
-    return CDIO_INQUIRY_VERSION_WEIRD;
-  }
-
-  /* The standard INQUIRY response contains the 'additional length' at byte 4.
-     The total response length is additional_length + 5. We requested a larger
-     buffer already; compute the actual available length from the device's
-     reported additional length to avoid reading past the device-returned
-     data. */
-  if (total_len > sizeof(buf)) {
-    total_len = sizeof(buf);
-  }
-
-  scsi_version = buf[2] & 0x07;
-
-  switch (scsi_version) {
-  case CDIO_INQUIRY_VERSION_1:
-  case CDIO_INQUIRY_VERSION_1a:
-  case CDIO_INQUIRY_VERSION_2:
-  case CDIO_INQUIRY_VERSION_3:
-  case CDIO_INQUIRY_VERSION_45:
-  case CDIO_INQUIRY_VERSION_5:
-    return (cdio_mmc_inquiry_version_t)scsi_version;
-  default:
-    return CDIO_INQUIRY_VERSION_WEIRD;
-  }
-}
 
 /**
    Get the MMC level supported by the device.

--- a/lib/driver/mmc/mmc.c
+++ b/lib/driver/mmc/mmc.c
@@ -47,6 +47,7 @@
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
+#include <assert.h>
 
 const char *mmc_cmd2str(uint8_t command) {
   switch (command) {
@@ -834,14 +835,14 @@ mmc_get_drive_cap (CdIo_t *p_cdio,
    (standard). Fills buf up to buf_len and returns 0 on success or negative on
    error.
 */
-static int mmc_issue_inquiry(CdIo_t *p_cdio, uint8_t *buf, size_t buf_len) {
+static int mmc_issue_inquiry(CdIo_t *p_cdio, uint8_t *buf, uint8_t buf_len) {
   mmc_cdb_t cdb = {.field = {
-                       CDIO_MMC_GPCMD_INQUIRY,
-                       0x00, /* EVPD = 0, standard INQUIRY */
-                       0x00, /* Page code (unused when EVPD=0) */
-                       0x00, (uint8_t)buf_len, /* Allocation length */
-                       0x00                    /* Control */
-                   }};
+       CDIO_MMC_GPCMD_INQUIRY, 0x00, /* EVPD = 0, standard INQUIRY */
+       0x00, /* Page code (unused when EVPD=0) */
+       0x00, /* MSB allocation length is 0. */
+       0x00, buf_len, /* LSB allocation length */
+       0x00  /* Control */
+    }};
   int i_status;
 
   if (!p_cdio)
@@ -859,17 +860,19 @@ static int mmc_issue_inquiry(CdIo_t *p_cdio, uint8_t *buf, size_t buf_len) {
    @return the drive capabilities.
 */
 
-/* Size we request from INQUIRY: large enough to include version descriptors */
+/* Size we request from INQUIRY: large enough to include version descriptors.
+   Note: this should be less than 256 so the number fits in one byte.
+ */
 #define MMC_INQUIRY_ALLOC 252
 
 /**
-   Get the MMC level supported by the device.
+   Get the MMC level supported by the device via INQUIRY and the Version field..
 
-   Parse INQUIRY standard data and search for version descriptors indicating
-   MMC support. Returns CDIO_MMC_LEVEL_* or CDIO_MMC_LEVEL_NONE on transport
+   Parse INQUIRY Version and search for version descriptors indicating
+   MMC support. Returns CDIO_INQUIRY_VERSION_* or CDIO_INQUIRY_VERSION_NONE on transport
    failure.
 */
-cdio_mmc_level_t mmc_get_drive_mmc_cap(CdIo_t *p_cdio)
+cdio_mmc_inquiry_version_t mmc_get_drive_mmc_cap_from_inquiry_version(CdIo_t *p_cdio)
 {
   /* Largest buffer size we use. */
   uint8_t buf[MMC_INQUIRY_ALLOC];
@@ -880,13 +883,13 @@ cdio_mmc_level_t mmc_get_drive_mmc_cap(CdIo_t *p_cdio)
 
   if (rc != 0) {
     /* transport failure */
-    return CDIO_MMC_LEVEL_NONE;
+    return CDIO_INQUIRY_VERSION_NONE;
   }
 
   /* Basic sanity checks: minimum INQUIRY length is 36 bytes (standard) */
   if (buf[4] < 31) {
     /* additional length field too small to contain version descriptors */
-    return CDIO_MMC_LEVEL_WEIRD;
+    return CDIO_INQUIRY_VERSION_WEIRD;
   }
 
   /* The standard INQUIRY response contains the 'additional length' at byte 4.
@@ -901,14 +904,43 @@ cdio_mmc_level_t mmc_get_drive_mmc_cap(CdIo_t *p_cdio)
   scsi_version = buf[2] & 0x07;
 
   switch (scsi_version) {
-  case CDIO_MMC_LEVEL_1:
-  case CDIO_MMC_LEVEL_1a:
-  case CDIO_MMC_LEVEL_2:
-  case CDIO_MMC_LEVEL_3:
-  case CDIO_MMC_LEVEL_45:
-  case CDIO_MMC_LEVEL_5:
-    return (cdio_mmc_level_t)scsi_version;
+  case CDIO_INQUIRY_VERSION_1:
+  case CDIO_INQUIRY_VERSION_1a:
+  case CDIO_INQUIRY_VERSION_2:
+  case CDIO_INQUIRY_VERSION_3:
+  case CDIO_INQUIRY_VERSION_45:
+  case CDIO_INQUIRY_VERSION_5:
+    return (cdio_mmc_inquiry_version_t)scsi_version;
   default:
+    return CDIO_INQUIRY_VERSION_WEIRD;
+  }
+}
+
+/**
+   Get the MMC level supported by the device.
+*/
+cdio_mmc_level_t
+mmc_get_drive_mmc_cap(CdIo_t *p_cdio)
+{
+  uint8_t buf[256] = { 0, };
+  uint8_t len;
+  int rc = mmc_mode_sense(p_cdio, buf, sizeof(buf),
+			  CDIO_MMC_CAPABILITIES_PAGE);
+
+  if (DRIVER_OP_SUCCESS != rc) {
+    return CDIO_MMC_LEVEL_NONE;
+  }
+
+  len = buf[1];
+  if (16 > len) {
+    return CDIO_MMC_LEVEL_WEIRD;
+  } else if (28 <= len) {
+    return CDIO_MMC_LEVEL_3;
+  } else if (24 <= len) {
+    return CDIO_MMC_LEVEL_2;
+  } else if (20 <= len) {
+    return CDIO_MMC_LEVEL_1;
+  } else {
     return CDIO_MMC_LEVEL_WEIRD;
   }
 }

--- a/lib/driver/mmc/mmc.c
+++ b/lib/driver/mmc/mmc.c
@@ -1,5 +1,5 @@
 /* Common Multimedia Command (MMC) routines.
-  Copyright (C) 2004-2008, 2010-2012, 2014, 2025
+  Copyright (C) 2004-2008, 2010-2012, 2014, 2025-2026
   Rocky Bernstein <rocky@gnu.org>
 
   This program is free software: you can redistribute it and/or modify
@@ -17,20 +17,20 @@
 */
 
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include "config.h"
 #endif
 
 #ifdef HAVE_STDBOOL_H
-# include <stdbool.h>
+#include <stdbool.h>
 #endif
 
+#include "cdio_private.h"
+#include "cdtext_private.h"
 #include <cdio/cdio.h>
 #include <cdio/logging.h>
 #include <cdio/mmc.h>
 #include <cdio/mmc_cmds.h>
 #include <cdio/util.h>
-#include "cdio_private.h"
-#include "cdtext_private.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>
@@ -41,17 +41,15 @@
 #endif
 
 #ifdef HAVE_STDIO_H
-# include <stdio.h>
+#include <stdio.h>
 #endif
 
 #ifdef HAVE_ERRNO_H
-# include <errno.h>
+#include <errno.h>
 #endif
 
-const char
-*mmc_cmd2str(uint8_t command)
-{
-  switch( command ) {
+const char *mmc_cmd2str(uint8_t command) {
+  switch (command) {
   case CDIO_MMC_GPCMD_TEST_UNIT_READY:
     return "TEST UNIT READY";
 
@@ -98,7 +96,7 @@ const char
     return "WRITE AND VERIFY (10)";
 
   case CDIO_MMC_GPCMD_VERIFY_10:
-   return "VERIFY (10)";
+    return "VERIFY (10)";
 
   case CDIO_MMC_GPCMD_SYNCHRONIZE_CACHE:
     return "SYNCHRONIZE CACHE";
@@ -247,12 +245,11 @@ const char
   case CDIO_MMC_GPCMD_READ_ALL_SUBCODES:
     return "READ ALL SUBCODES";
 
-  default:
-    {
-      char buf[30];
-      snprintf(buf, sizeof(buf), "Unknown 0x%x", command);
-      return strdup(buf);
-    }
+  default: {
+    char buf[30];
+    snprintf(buf, sizeof(buf), "Unknown 0x%x", command);
+    return strdup(buf);
+  }
   }
 }
 
@@ -271,10 +268,10 @@ const char
 
 */
 driver_return_code_t
-audio_read_subchannel_mmc ( void *p_user_data, cdio_subchannel_t *p_subchannel)
-{
+audio_read_subchannel_mmc(void *p_user_data, cdio_subchannel_t *p_subchannel) {
   generic_img_private_t *p_env = p_user_data;
-  if (!p_env) return DRIVER_OP_UNINIT;
+  if (!p_env)
+    return DRIVER_OP_UNINIT;
   return mmc_audio_read_subchannel(p_env->cdio, p_subchannel);
 }
 
@@ -282,34 +279,29 @@ audio_read_subchannel_mmc ( void *p_user_data, cdio_subchannel_t *p_subchannel)
   Get the block size for subsequent read requests, via MMC.
   @return the blocksize if > 0; error if <= 0
  */
-int
-get_blocksize_mmc (void *p_user_data)
-{
-    generic_img_private_t *p_env = p_user_data;
-    if (!p_env) return DRIVER_OP_UNINIT;
-    return mmc_get_blocksize(p_env->cdio);
+int get_blocksize_mmc(void *p_user_data) {
+  generic_img_private_t *p_env = p_user_data;
+  if (!p_env)
+    return DRIVER_OP_UNINIT;
+  return mmc_get_blocksize(p_env->cdio);
 }
 
 /**
   Get the lsn of the end of the CD (via MMC).
 */
-lsn_t
-get_disc_last_lsn_mmc (void *p_user_data)
-{
-    generic_img_private_t *p_env = p_user_data;
-    if (!p_env) return CDIO_INVALID_LSN;
-    return mmc_get_disc_last_lsn(p_env->cdio);
+lsn_t get_disc_last_lsn_mmc(void *p_user_data) {
+  generic_img_private_t *p_env = p_user_data;
+  if (!p_env)
+    return CDIO_INVALID_LSN;
+  return mmc_get_disc_last_lsn(p_env->cdio);
 }
 
-void
-get_drive_cap_mmc (const void *p_user_data,
-		   /*out*/ cdio_drive_read_cap_t  *p_read_cap,
-		   /*out*/ cdio_drive_write_cap_t *p_write_cap,
-		   /*out*/ cdio_drive_misc_cap_t  *p_misc_cap)
-{
+void get_drive_cap_mmc(const void *p_user_data,
+                       /*out*/ cdio_drive_read_cap_t *p_read_cap,
+                       /*out*/ cdio_drive_write_cap_t *p_write_cap,
+                       /*out*/ cdio_drive_misc_cap_t *p_misc_cap) {
   const generic_img_private_t *p_env = p_user_data;
-  mmc_get_drive_cap( p_env->cdio,
-                     p_read_cap, p_write_cap, p_misc_cap );
+  mmc_get_drive_cap(p_env->cdio, p_read_cap, p_write_cap, p_misc_cap);
 }
 
 /**
@@ -318,97 +310,82 @@ get_drive_cap_mmc (const void *p_user_data,
     @return 1 if media has changed since last call, 0 if not. Error
     return codes are the same as driver_return_code_t
 */
-int
-get_media_changed_mmc (const void *p_user_data)
-{
+int get_media_changed_mmc(const void *p_user_data) {
   const generic_img_private_t *p_env = p_user_data;
-  return mmc_get_media_changed( p_env->cdio );
+  return mmc_get_media_changed(p_env->cdio);
 }
 
-char *
-get_mcn_mmc (const void *p_user_data)
-{
+char *get_mcn_mmc(const void *p_user_data) {
   const generic_img_private_t *p_env = p_user_data;
-  return mmc_get_mcn( p_env->cdio );
+  return mmc_get_mcn(p_env->cdio);
 }
 
-driver_return_code_t
-get_tray_status (const void *p_user_data)
-{
-    const generic_img_private_t *p_env = p_user_data;
-    return mmc_get_tray_status( p_env->cdio );
+driver_return_code_t get_tray_status(const void *p_user_data) {
+  const generic_img_private_t *p_env = p_user_data;
+  return mmc_get_tray_status(p_env->cdio);
 }
 
 /**
     Read sectors using SCSI-MMC GPCMD_READ_CD.
  */
-driver_return_code_t
-mmc_read_data_sectors ( CdIo_t *p_cdio, void *p_buf,
-                        lsn_t i_lsn,  uint16_t i_blocksize,
-                        uint32_t i_blocks )
-{
-  return mmc_read_cd(p_cdio,
-                     p_buf, /* place to store data */
-                     i_lsn, /* lsn */
-                     0, /* read_sector_type */
-                     false, /* digital audio play */
-                     false, /* return sync header */
-                     0,     /* header codes */
-                     true,  /* return user data */
-                     false, /* return EDC ECC */
-                     false, /* return C2 Error information */
-                     0,     /* subchannel selection bits */
+driver_return_code_t mmc_read_data_sectors(CdIo_t *p_cdio, void *p_buf,
+                                           lsn_t i_lsn, uint16_t i_blocksize,
+                                           uint32_t i_blocks) {
+  return mmc_read_cd(p_cdio, p_buf, /* place to store data */
+                     i_lsn,         /* lsn */
+                     0,             /* read_sector_type */
+                     false,         /* digital audio play */
+                     false,         /* return sync header */
+                     0,             /* header codes */
+                     true,          /* return user data */
+                     false,         /* return EDC ECC */
+                     false,         /* return C2 Error information */
+                     0,             /* subchannel selection bits */
                      ISO_BLOCKSIZE, /* blocksize*/
-                     i_blocks       /* Number of blocks. */);
-
+                     i_blocks /* Number of blocks. */);
 }
-
 
 /**
    Read sectors using SCSI-MMC GPCMD_READ_CD.
    Can read only up to 25 blocks.
  */
-driver_return_code_t
-read_data_sectors_mmc ( void *p_user_data, void *p_buf,
-                        lsn_t i_lsn,  uint16_t i_blocksize,
-                        uint32_t i_blocks )
-{
-    const generic_img_private_t *p_env = p_user_data;
-    return mmc_read_data_sectors( p_env->cdio, p_buf, i_lsn, i_blocksize,
-                                i_blocks );
+driver_return_code_t read_data_sectors_mmc(void *p_user_data, void *p_buf,
+                                           lsn_t i_lsn, uint16_t i_blocksize,
+                                           uint32_t i_blocks) {
+  const generic_img_private_t *p_env = p_user_data;
+  return mmc_read_data_sectors(p_env->cdio, p_buf, i_lsn, i_blocksize,
+                               i_blocks);
 }
 
 /**
     Set read blocksize (via MMC)
 */
-driver_return_code_t
-set_blocksize_mmc (void *p_user_data, uint16_t i_blocksize)
-{
-    generic_img_private_t *p_env = p_user_data;
-    if (!p_env) return DRIVER_OP_UNINIT;
-    return mmc_set_blocksize(p_env->cdio, i_blocksize);
+driver_return_code_t set_blocksize_mmc(void *p_user_data,
+                                       uint16_t i_blocksize) {
+  generic_img_private_t *p_env = p_user_data;
+  if (!p_env)
+    return DRIVER_OP_UNINIT;
+  return mmc_set_blocksize(p_env->cdio, i_blocksize);
 }
 
 /** Set the drive speed Set the drive speed in K bytes per second. (via
    MMC).
 */
-driver_return_code_t
-set_speed_mmc (void *p_user_data, int i_speed)
-{
-    generic_img_private_t *p_env = p_user_data;
-    if (!p_env) return DRIVER_OP_UNINIT;
-    return mmc_set_speed( p_env->cdio, i_speed, 0);
+driver_return_code_t set_speed_mmc(void *p_user_data, int i_speed) {
+  generic_img_private_t *p_env = p_user_data;
+  if (!p_env)
+    return DRIVER_OP_UNINIT;
+  return mmc_set_speed(p_env->cdio, i_speed, 0);
 }
 
 /**
    Set the drive speed in CD-ROM speed units (via MMC).
 */
-driver_return_code_t
-set_drive_speed_mmc (void *p_user_data, int i_Kbs_speed)
-{
+driver_return_code_t set_drive_speed_mmc(void *p_user_data, int i_Kbs_speed) {
   generic_img_private_t *p_env = p_user_data;
-  if (!p_env) return DRIVER_OP_UNINIT;
-  return mmc_set_drive_speed( p_env->cdio, i_Kbs_speed );
+  if (!p_env)
+    return DRIVER_OP_UNINIT;
+  return mmc_set_drive_speed(p_env->cdio, i_Kbs_speed);
 }
 
 /**
@@ -417,20 +394,19 @@ set_drive_speed_mmc (void *p_user_data, int i_Kbs_speed)
     Page.
 */
 driver_return_code_t
-mmc_audio_get_volume( CdIo_t *p_cdio, /*out*/ mmc_audio_volume_t *p_volume )
-{
+mmc_audio_get_volume(CdIo_t *p_cdio, /*out*/ mmc_audio_volume_t *p_volume) {
   uint8_t buf[16];
   int i_rc = mmc_mode_sense(p_cdio, buf, sizeof(buf), CDIO_MMC_AUDIO_CTL_PAGE);
 
-  if ( DRIVER_OP_SUCCESS == i_rc ) {
+  if (DRIVER_OP_SUCCESS == i_rc) {
     p_volume->port[0].selection = 0xF & buf[8];
-    p_volume->port[0].volume    = buf[9];
+    p_volume->port[0].volume = buf[9];
     p_volume->port[1].selection = 0xF & buf[10];
-    p_volume->port[1].volume    = buf[11];
+    p_volume->port[1].volume = buf[11];
     p_volume->port[2].selection = 0xF & buf[12];
-    p_volume->port[2].volume    = buf[13];
+    p_volume->port[2].volume = buf[13];
     p_volume->port[3].selection = 0xF & buf[14];
-    p_volume->port[3].volume    = buf[15];
+    p_volume->port[3].volume = buf[15];
     return DRIVER_OP_SUCCESS;
   }
   return i_rc;
@@ -439,20 +415,22 @@ mmc_audio_get_volume( CdIo_t *p_cdio, /*out*/ mmc_audio_volume_t *p_volume )
 /**
   Get the DVD type associated with cd object.
 */
-discmode_t
-mmc_get_dvd_struct_physical_private ( void *p_env,
-                                      mmc_run_cmd_fn_t run_mmc_cmd,
-                                      cdio_dvd_struct_t *s)
-{
-  mmc_cdb_t cdb = {{0, }};
+discmode_t mmc_get_dvd_struct_physical_private(void *p_env,
+                                               mmc_run_cmd_fn_t run_mmc_cmd,
+                                               cdio_dvd_struct_t *s) {
+  mmc_cdb_t cdb = {{
+      0,
+  }};
   unsigned char buf[4 + 4 * 20], *base;
   int i_status;
   uint8_t layer_num = s->physical.layer_num;
 
   cdio_dvd_layer_t *layer;
 
-  if (!p_env) return DRIVER_OP_UNINIT;
-  if (!run_mmc_cmd) return DRIVER_OP_UNSUPPORTED;
+  if (!p_env)
+    return DRIVER_OP_UNINIT;
+  if (!run_mmc_cmd)
+    return DRIVER_OP_UNSUPPORTED;
 
   if (layer_num >= CDIO_DVD_MAX_LAYERS)
     return -EINVAL;
@@ -462,10 +440,8 @@ mmc_get_dvd_struct_physical_private ( void *p_env,
   cdb.field[7] = CDIO_DVD_STRUCT_PHYSICAL;
   cdb.field[9] = sizeof(buf) & 0xff;
 
-  i_status = run_mmc_cmd(p_env, mmc_timeout_ms,
-			      mmc_get_cmd_len(cdb.field[0]),
-			      &cdb, SCSI_MMC_DATA_READ,
-			      sizeof(buf), &buf);
+  i_status = run_mmc_cmd(p_env, mmc_timeout_ms, mmc_get_cmd_len(cdb.field[0]),
+                         &cdb, SCSI_MMC_DATA_READ, sizeof(buf), &buf);
   if (0 != i_status)
     return CDIO_DISC_MODE_ERROR;
 
@@ -491,7 +467,7 @@ mmc_get_dvd_struct_physical_private ( void *p_env,
   layer->end_sector_l0 = base[13] << 16 | base[14] << 8 | base[15];
   layer->bca = base[16] >> 7;
 
-  return (discmode_t) DRIVER_OP_SUCCESS;
+  return (discmode_t)DRIVER_OP_SUCCESS;
 }
 
 /**
@@ -507,34 +483,30 @@ mmc_get_dvd_struct_physical_private ( void *p_env,
   @return malloc'd string holding the MCN or ISRC on success
           or NULL on failure
  */
-char *
-mmc_get_mcn_isrc_private ( const CdIo_t *p_cdio,
-                            track_t i_track,
-                            unsigned char sub_chan_param
-                  )
-{
+char *mmc_get_mcn_isrc_private(const CdIo_t *p_cdio, track_t i_track,
+                               unsigned char sub_chan_param) {
   char buf[24]; /* 4 header + 20 data (MMC-4 tables 424, 431, 432) */
   unsigned int num_data;
   size_t length;
   driver_return_code_t i_rc;
 
-  switch(sub_chan_param) {
-    case CDIO_SUBCHANNEL_MEDIA_CATALOG: /* MCN */
-      length = CDIO_MCN_SIZE;
-      break;
-    case CDIO_SUBCHANNEL_TRACK_ISRC: /* ISRC */
-      length = CDIO_ISRC_SIZE;
-      break;
-    default:
-      return NULL;
+  switch (sub_chan_param) {
+  case CDIO_SUBCHANNEL_MEDIA_CATALOG: /* MCN */
+    length = CDIO_MCN_SIZE;
+    break;
+  case CDIO_SUBCHANNEL_TRACK_ISRC: /* ISRC */
+    length = CDIO_ISRC_SIZE;
+    break;
+  default:
+    return NULL;
   }
 
   /* inquire number of available reply bytes
      workaround for bad device drivers
    */
   num_data = 4; /* header only */
-  i_rc = mmc_read_subchannel (p_cdio, i_track,
-                                   sub_chan_param, &num_data, buf, 0);
+  i_rc =
+      mmc_read_subchannel(p_cdio, i_track, sub_chan_param, &num_data, buf, 0);
 
   if (i_rc != DRIVER_OP_SUCCESS)
     return NULL;
@@ -543,32 +515,29 @@ mmc_get_mcn_isrc_private ( const CdIo_t *p_cdio,
     num_data = sizeof(buf);
 
   if (num_data < 9 + length)
-    return NULL;              /* Not enough data available */
+    return NULL; /* Not enough data available */
 
-  i_rc = mmc_read_subchannel (p_cdio, i_track,
-                                   sub_chan_param, &num_data, buf, 0);
+  i_rc =
+      mmc_read_subchannel(p_cdio, i_track, sub_chan_param, &num_data, buf, 0);
   if (i_rc != DRIVER_OP_SUCCESS)
     return NULL;
 
   if (num_data < 9 + length)
-    return NULL;              /* Not enough data returned */
+    return NULL; /* Not enough data returned */
 
-  if ( ! (buf[8] & 0x80) )    /* MCVAL / TCVAL bit indicates a valid response */
-    return NULL;              /* MCN/ISRC not valid */
+  if (!(buf[8] & 0x80)) /* MCVAL / TCVAL bit indicates a valid response */
+    return NULL;        /* MCN/ISRC not valid */
   return strndup(&buf[9], length);
 }
 
-
-
 driver_return_code_t
-mmc_set_blocksize_private ( void *p_env,
-                            const mmc_run_cmd_fn_t run_mmc_cmd,
-                            uint16_t i_blocksize)
-{
-  mmc_cdb_t cdb = {{0, }};
+mmc_set_blocksize_private(void *p_env, const mmc_run_cmd_fn_t run_mmc_cmd,
+                          uint16_t i_blocksize) {
+  mmc_cdb_t cdb = {{
+      0,
+  }};
 
-  struct
-  {
+  struct {
     uint8_t reserved1;
     uint8_t medium;
     uint8_t reserved2;
@@ -583,29 +552,28 @@ mmc_set_blocksize_private ( void *p_env,
     uint8_t block_length_lo;
   } mh;
 
-  if ( ! p_env ) return DRIVER_OP_UNINIT;
-  if ( ! run_mmc_cmd ) return DRIVER_OP_UNSUPPORTED;
+  if (!p_env)
+    return DRIVER_OP_UNINIT;
+  if (!run_mmc_cmd)
+    return DRIVER_OP_UNSUPPORTED;
 
-  memset (&mh, 0, sizeof (mh));
+  memset(&mh, 0, sizeof(mh));
   mh.block_desc_length = 0x08;
 
   /* while i_blocksize is uint16_t, this expression is always 0 */
-  mh.block_length_hi   = (i_blocksize >> 16) & 0xff;
+  mh.block_length_hi = (i_blocksize >> 16) & 0xff;
 
-  mh.block_length_med  = (i_blocksize >>  8) & 0xff;
-  mh.block_length_lo   = (i_blocksize >>  0) & 0xff;
+  mh.block_length_med = (i_blocksize >> 8) & 0xff;
+  mh.block_length_lo = (i_blocksize >> 0) & 0xff;
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_MODE_SELECT_6);
 
   cdb.field[1] = 1 << 4;
   cdb.field[4] = 12;
 
-  return run_mmc_cmd (p_env, mmc_timeout_ms,
-			      mmc_get_cmd_len(cdb.field[0]), &cdb,
-			      SCSI_MMC_DATA_WRITE, sizeof(mh), &mh);
+  return run_mmc_cmd(p_env, mmc_timeout_ms, mmc_get_cmd_len(cdb.field[0]), &cdb,
+                     SCSI_MMC_DATA_WRITE, sizeof(mh), &mh);
 }
-
-
 
 /***********************************************************
   User-accessible Operations.
@@ -616,13 +584,13 @@ mmc_set_blocksize_private ( void *p_env,
   @param p_cdio the CD object to be acted upon.
 */
 driver_return_code_t
-mmc_audio_read_subchannel (CdIo_t *p_cdio,  cdio_subchannel_t *p_subchannel)
-{
+mmc_audio_read_subchannel(CdIo_t *p_cdio, cdio_subchannel_t *p_subchannel) {
   mmc_cdb_t cdb;
   driver_return_code_t i_rc;
   cdio_mmc_subchannel_t mmc_subchannel;
 
-  if (!p_cdio) return DRIVER_OP_UNINIT;
+  if (!p_cdio)
+    return DRIVER_OP_UNINIT;
 
   memset(&mmc_subchannel, 0, sizeof(mmc_subchannel));
   mmc_subchannel.format = CDIO_CDROM_MSF;
@@ -634,23 +602,23 @@ mmc_audio_read_subchannel (CdIo_t *p_cdio,  cdio_subchannel_t *p_subchannel)
   cdb.field[1] = CDIO_CDROM_MSF;
   cdb.field[2] = 0x40; /* subq */
   cdb.field[3] = CDIO_SUBCHANNEL_CURRENT_POSITION;
-  cdb.field[6] = 0;    /* track number (only in isrc mode, ignored) */
+  cdb.field[6] = 0; /* track number (only in isrc mode, ignored) */
 
   i_rc = mmc_run_cmd(p_cdio, mmc_timeout_ms, &cdb, SCSI_MMC_DATA_READ,
                      sizeof(cdio_mmc_subchannel_t), &mmc_subchannel);
   if (DRIVER_OP_SUCCESS == i_rc) {
-    p_subchannel->format       = mmc_subchannel.format;
+    p_subchannel->format = mmc_subchannel.format;
     p_subchannel->audio_status = mmc_subchannel.audio_status;
-    p_subchannel->address      = mmc_subchannel.address;
-    p_subchannel->control      = mmc_subchannel.control;
-    p_subchannel->track        = mmc_subchannel.track;
-    p_subchannel->index        = mmc_subchannel.index;
-    p_subchannel->abs_addr.m   = cdio_to_bcd8(mmc_subchannel.abs_addr[1]);
-    p_subchannel->abs_addr.s   = cdio_to_bcd8(mmc_subchannel.abs_addr[2]);
-    p_subchannel->abs_addr.f   = cdio_to_bcd8(mmc_subchannel.abs_addr[3]);
-    p_subchannel->rel_addr.m   = cdio_to_bcd8(mmc_subchannel.rel_addr[1]);
-    p_subchannel->rel_addr.s   = cdio_to_bcd8(mmc_subchannel.rel_addr[2]);
-    p_subchannel->rel_addr.f   = cdio_to_bcd8(mmc_subchannel.rel_addr[3]);
+    p_subchannel->address = mmc_subchannel.address;
+    p_subchannel->control = mmc_subchannel.control;
+    p_subchannel->track = mmc_subchannel.track;
+    p_subchannel->index = mmc_subchannel.index;
+    p_subchannel->abs_addr.m = cdio_to_bcd8(mmc_subchannel.abs_addr[1]);
+    p_subchannel->abs_addr.s = cdio_to_bcd8(mmc_subchannel.abs_addr[2]);
+    p_subchannel->abs_addr.f = cdio_to_bcd8(mmc_subchannel.abs_addr[3]);
+    p_subchannel->rel_addr.m = cdio_to_bcd8(mmc_subchannel.rel_addr[1]);
+    p_subchannel->rel_addr.s = cdio_to_bcd8(mmc_subchannel.rel_addr[2]);
+    p_subchannel->rel_addr.f = cdio_to_bcd8(mmc_subchannel.rel_addr[3]);
   }
   return i_rc;
 }
@@ -662,53 +630,40 @@ mmc_audio_read_subchannel (CdIo_t *p_cdio,  cdio_subchannel_t *p_subchannel)
    @param p_cdio the CD object to be acted upon.
    @return the blocksize if > 0; error if <= 0
 */
-int
-mmc_get_blocksize ( CdIo_t *p_cdio)
-{
+int mmc_get_blocksize(CdIo_t *p_cdio) {
   int i_status;
 
-  uint8_t buf[255] = { 0, };
+  uint8_t buf[255] = {
+      0,
+  };
   uint8_t *p;
 
   /* First try using the 6-byte MODE SENSE command. */
-  i_status = mmc_mode_sense_6(p_cdio, buf, sizeof(buf),
-                              CDIO_MMC_R_W_ERROR_PAGE);
+  i_status =
+      mmc_mode_sense_6(p_cdio, buf, sizeof(buf), CDIO_MMC_R_W_ERROR_PAGE);
 
-  if (DRIVER_OP_SUCCESS == i_status && buf[3]>=8) {
-    p = &buf[4+5];
+  if (DRIVER_OP_SUCCESS == i_status && buf[3] >= 8) {
+    p = &buf[4 + 5];
     return CDIO_MMC_GET_LEN16(p);
   }
 
   /* Next try using the 10-byte MODE SENSE command. */
-  i_status = mmc_mode_sense_10(p_cdio, buf, sizeof(buf),
-                               CDIO_MMC_R_W_ERROR_PAGE);
+  i_status =
+      mmc_mode_sense_10(p_cdio, buf, sizeof(buf), CDIO_MMC_R_W_ERROR_PAGE);
   p = &buf[6];
-  if (DRIVER_OP_SUCCESS == i_status && CDIO_MMC_GET_LEN16(p)>=8) {
+  if (DRIVER_OP_SUCCESS == i_status && CDIO_MMC_GET_LEN16(p) >= 8) {
     return CDIO_MMC_GET_LEN16(p);
   }
-
-#ifdef IS_THIS_CORRECT
-  /* Lastly try using the READ CAPACITY command. */
-  {
-    lba_t    lba = 0;
-    uint16_t i_blocksize;
-
-    i_status = mmc_read_capacity(p_cdio, &lba, &i_blocksize);
-    if ( DRIVER_OP_SUCCESS == i_status )
-      return i_blocksize;
-#endif
 
   return DRIVER_OP_UNSUPPORTED;
 }
 
 /**
-  Return the number of length in bytes of the Command Descriptor
-  buffer (CDB) for a given MMC command. The length will be
-  either 6, 10, or 12.
+   Return the number of length in bytes of the Command Descriptor
+   buffer (CDB) for a given MMC command. The length will be
+   either 6, 10, or 12.
 */
-uint8_t
-mmc_get_cmd_len(uint8_t scsi_cmd)
-{
+uint8_t mmc_get_cmd_len(uint8_t scsi_cmd) {
   static const uint8_t scsi_cdblen[8] = {6, 10, 10, 12, 12, 12, 10, 10};
   return scsi_cdblen[((scsi_cmd >> 5) & 7)];
 }
@@ -717,12 +672,14 @@ mmc_get_cmd_len(uint8_t scsi_cmd)
    Return the size of the CD in logical block address (LBA) units.
    @param p_cdio the CD object to be acted upon.
    @return the lsn. On error 0 or CDIO_INVALD_LSN.
- */
-lsn_t
-mmc_get_disc_last_lsn ( const CdIo_t *p_cdio )
-{
-  mmc_cdb_t cdb = {{0, }};
-  uint8_t buf[12] = { 0, };
+*/
+lsn_t mmc_get_disc_last_lsn(const CdIo_t *p_cdio) {
+  mmc_cdb_t cdb = {{
+      0,
+  }};
+  uint8_t buf[12] = {
+      0,
+  };
 
   lsn_t retval = 0;
   int i_status;
@@ -742,7 +699,8 @@ mmc_get_disc_last_lsn ( const CdIo_t *p_cdio )
   i_status = mmc_run_cmd(p_cdio, mmc_timeout_ms, &cdb, SCSI_MMC_DATA_READ,
                          sizeof(buf), buf);
 
-  if (i_status) return CDIO_INVALID_LSN;
+  if (i_status)
+    return CDIO_INVALID_LSN;
 
   {
     int i;
@@ -756,19 +714,20 @@ mmc_get_disc_last_lsn ( const CdIo_t *p_cdio )
 }
 
 /**
-  Return the discmode as reported by the SCSI-MMC Read (FULL) TOC
-  command.
+   Return the discmode as reported by the SCSI-MMC Read (FULL) TOC
+   command.
 
-  Information was obtained from Section 5.1.13 (Read TOC/PMA/ATIP)
-  pages 56-62 from the MMC draft specification, revision 10a
-  at http://www.t10.org/ftp/t10/drafts/mmc/mmc-r10a.pdf See
-  especially tables 72, 73 and 75.
+   Information was obtained from Section 5.1.13 (Read TOC/PMA/ATIP)
+   pages 56-62 from the MMC draft specification, revision 10a
+   at http://www.t10.org/ftp/t10/drafts/mmc/mmc-r10a.pdf See
+   especially tables 72, 73 and 75.
 */
-discmode_t
-mmc_get_discmode( const CdIo_t *p_cdio )
+discmode_t mmc_get_discmode(const CdIo_t *p_cdio)
 
 {
-  uint8_t buf[14] = { 0, };
+  uint8_t buf[14] = {
+      0,
+  };
   mmc_cdb_t cdb;
 
   memset(&cdb, 0, sizeof(mmc_cdb_t));
@@ -783,14 +742,13 @@ mmc_get_discmode( const CdIo_t *p_cdio )
   if (buf[7] == 0xA0) {
     if (buf[13] == 0x00) {
       if (buf[5] & 0x04)
-	return CDIO_DISC_MODE_CD_DATA;
+        return CDIO_DISC_MODE_CD_DATA;
       else
-	return CDIO_DISC_MODE_CD_DA;
-    }
-    else if (buf[13] == 0x10)
+        return CDIO_DISC_MODE_CD_DA;
+    } else if (buf[13] == 0x10)
       return CDIO_DISC_MODE_CD_I;
     else if (buf[13] == 0x20)
-    return CDIO_DISC_MODE_CD_XA;
+      return CDIO_DISC_MODE_CD_XA;
   }
   return CDIO_DISC_MODE_NO_INFO;
 }
@@ -872,31 +830,85 @@ mmc_get_drive_cap (CdIo_t *p_cdio,
   return;
 }
 
+/* Helper: issue plain SCSI INQUIRY (CDIO_MMC_GPCMD_INQUIRY), EVPD = 0
+   (standard). Fills buf up to buf_len and returns 0 on success or negative on
+   error.
+*/
+static int mmc_issue_inquiry(CdIo_t *p_cdio, uint8_t *buf, size_t buf_len) {
+  mmc_cdb_t cdb = {.field = {
+                       CDIO_MMC_GPCMD_INQUIRY,
+                       0x00, /* EVPD = 0, standard INQUIRY */
+                       0x00, /* Page code (unused when EVPD=0) */
+                       0x00, (uint8_t)buf_len, /* Allocation length */
+                       0x00                    /* Control */
+                   }};
+  int i_status;
+
+  if (!p_cdio)
+    return -1;
+
+  CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_INQUIRY);
+
+  i_status = mmc_run_cmd(p_cdio, mmc_timeout_ms, &cdb, SCSI_MMC_DATA_READ,
+                         sizeof(buf), &buf);
+  return i_status;
+}
+/**
+   Get drive capabilities for a device.
+   @param p_cdio the CD object to be acted upon.
+   @return the drive capabilities.
+*/
+
+/* Size we request from INQUIRY: large enough to include version descriptors */
+#define MMC_INQUIRY_ALLOC 252
+
 /**
    Get the MMC level supported by the device.
-*/
-cdio_mmc_level_t
-mmc_get_drive_mmc_cap(CdIo_t *p_cdio)
-{
-  uint8_t buf[256] = { 0, };
-  uint8_t len;
-  int rc = mmc_mode_sense(p_cdio, buf, sizeof(buf),
-			  CDIO_MMC_CAPABILITIES_PAGE);
 
-  if (DRIVER_OP_SUCCESS != rc) {
+   Parse INQUIRY standard data and search for version descriptors indicating
+   MMC support. Returns CDIO_MMC_LEVEL_* or CDIO_MMC_LEVEL_NONE on transport
+   failure.
+*/
+cdio_mmc_level_t mmc_get_drive_mmc_cap(CdIo_t *p_cdio)
+{
+  /* Largest buffer size we use. */
+  uint8_t buf[MMC_INQUIRY_ALLOC];
+  uint8_t scsi_version;
+  int rc = mmc_issue_inquiry(p_cdio, buf, sizeof(buf));
+  size_t additional_len = (size_t)buf[4];
+  size_t total_len = 5 + additional_len;
+
+  if (rc != 0) {
+    /* transport failure */
     return CDIO_MMC_LEVEL_NONE;
   }
 
-  len = buf[1];
-  if (16 > len) {
+  /* Basic sanity checks: minimum INQUIRY length is 36 bytes (standard) */
+  if (buf[4] < 31) {
+    /* additional length field too small to contain version descriptors */
     return CDIO_MMC_LEVEL_WEIRD;
-  } else if (28 <= len) {
-    return CDIO_MMC_LEVEL_3;
-  } else if (24 <= len) {
-    return CDIO_MMC_LEVEL_2;
-  } else if (20 <= len) {
-    return CDIO_MMC_LEVEL_1;
-  } else {
+  }
+
+  /* The standard INQUIRY response contains the 'additional length' at byte 4.
+     The total response length is additional_length + 5. We requested a larger
+     buffer already; compute the actual available length from the device's
+     reported additional length to avoid reading past the device-returned
+     data. */
+  if (total_len > sizeof(buf)) {
+    total_len = sizeof(buf);
+  }
+
+  scsi_version = buf[2] & 0x07;
+
+  switch (scsi_version) {
+  case CDIO_MMC_LEVEL_1:
+  case CDIO_MMC_LEVEL_1a:
+  case CDIO_MMC_LEVEL_2:
+  case CDIO_MMC_LEVEL_3:
+  case CDIO_MMC_LEVEL_45:
+  case CDIO_MMC_LEVEL_5:
+    return (cdio_mmc_level_t)scsi_version;
+  default:
     return CDIO_MMC_LEVEL_WEIRD;
   }
 }
@@ -907,14 +919,12 @@ mmc_get_drive_mmc_cap(CdIo_t *p_cdio)
    @param p_cdio the CD object to be acted upon.
    @return the DVD discmode.
 */
-discmode_t
-mmc_get_dvd_struct_physical ( const CdIo_t *p_cdio, cdio_dvd_struct_t *s)
-{
-  if ( ! p_cdio )  return -2;
-  return
-    mmc_get_dvd_struct_physical_private (p_cdio->env,
-                                         p_cdio->op.run_mmc_cmd,
-                                         s);
+discmode_t mmc_get_dvd_struct_physical(const CdIo_t *p_cdio,
+                                       cdio_dvd_struct_t *s) {
+  if (!p_cdio)
+    return -2;
+  return mmc_get_dvd_struct_physical_private(p_cdio->env,
+                                             p_cdio->op.run_mmc_cmd, s);
 }
 
 /**
@@ -925,38 +935,37 @@ mmc_get_dvd_struct_physical ( const CdIo_t *p_cdio, cdio_dvd_struct_t *s)
   @return true if we were able to get hardware info, false if we had
   an error.
 */
-bool
-mmc_get_hwinfo ( const CdIo_t *p_cdio,
-		      /*out*/ cdio_hwinfo_t *hw_info )
-{
-  int i_status;                  /* Result of MMC command */
-  char buf[36] = { 0, };         /* Place to hold returned data */
-  mmc_cdb_t cdb = {{0, }};  /* Command Descriptor Block */
+bool mmc_get_hwinfo(const CdIo_t *p_cdio,
+                    /*out*/ cdio_hwinfo_t *hw_info) {
+  int i_status; /* Result of MMC command */
+  char buf[36] = {
+      0,
+  }; /* Place to hold returned data */
+  mmc_cdb_t cdb = {{
+      0,
+  }}; /* Command Descriptor Block */
+
+  if (!p_cdio || !hw_info)
+    return false;
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_INQUIRY);
   cdb.field[4] = sizeof(buf);
 
-  if (! p_cdio || ! hw_info ) return false;
-
-  i_status = mmc_run_cmd(p_cdio, mmc_timeout_ms,
-			      &cdb, SCSI_MMC_DATA_READ,
-			      sizeof(buf), &buf);
+  i_status = mmc_run_cmd(p_cdio, mmc_timeout_ms, &cdb, SCSI_MMC_DATA_READ,
+                         sizeof(buf), &buf);
   if (i_status == 0) {
 
-      memcpy(hw_info->psz_vendor,
-	     buf + 8,
-	     sizeof(hw_info->psz_vendor)-1);
-      hw_info->psz_vendor[sizeof(hw_info->psz_vendor)-1] = '\0';
-      memcpy(hw_info->psz_model,
-	     buf + 8 + CDIO_MMC_HW_VENDOR_LEN,
-	     sizeof(hw_info->psz_model)-1);
-      hw_info->psz_model[sizeof(hw_info->psz_model)-1] = '\0';
-      memcpy(hw_info->psz_revision,
-	     buf + 8 + CDIO_MMC_HW_VENDOR_LEN + CDIO_MMC_HW_MODEL_LEN,
-	     sizeof(hw_info->psz_revision)-1);
-      hw_info->psz_revision[sizeof(hw_info->psz_revision)-1] = '\0';
-      return true;
-    }
+    memcpy(hw_info->psz_vendor, buf + 8, sizeof(hw_info->psz_vendor) - 1);
+    hw_info->psz_vendor[sizeof(hw_info->psz_vendor) - 1] = '\0';
+    memcpy(hw_info->psz_model, buf + 8 + CDIO_MMC_HW_VENDOR_LEN,
+           sizeof(hw_info->psz_model) - 1);
+    hw_info->psz_model[sizeof(hw_info->psz_model) - 1] = '\0';
+    memcpy(hw_info->psz_revision,
+           buf + 8 + CDIO_MMC_HW_VENDOR_LEN + CDIO_MMC_HW_MODEL_LEN,
+           sizeof(hw_info->psz_revision) - 1);
+    hw_info->psz_revision[sizeof(hw_info->psz_revision) - 1] = '\0';
+    return true;
+  }
   return false;
 }
 
@@ -966,8 +975,7 @@ mmc_get_hwinfo ( const CdIo_t *p_cdio,
   @return 1 if media has changed since last call, 0 if not. Error
   return codes are the same as driver_return_code_t
 */
-int mmc_get_media_changed(const CdIo_t *p_cdio)
-{
+int mmc_get_media_changed(const CdIo_t *p_cdio) {
   uint8_t status_buf[2];
   int i_status;
 
@@ -988,11 +996,10 @@ int mmc_get_media_changed(const CdIo_t *p_cdio)
    when done with it.
 
 */
-char *
-mmc_get_mcn ( const CdIo_t *p_cdio )
-{
-  if ( ! p_cdio )  return NULL;
-  return mmc_get_mcn_isrc_private (p_cdio, 0, CDIO_SUBCHANNEL_MEDIA_CATALOG );
+char *mmc_get_mcn(const CdIo_t *p_cdio) {
+  if (!p_cdio)
+    return NULL;
+  return mmc_get_mcn_isrc_private(p_cdio, 0, CDIO_SUBCHANNEL_MEDIA_CATALOG);
 }
 
 /**
@@ -1006,32 +1013,29 @@ mmc_get_mcn ( const CdIo_t *p_cdio )
    when done with it.
 
 */
-char *
-mmc_get_track_isrc ( const CdIo_t *p_cdio, track_t i_track )
-{
-  if ( ! p_cdio )  return NULL;
-  return mmc_get_mcn_isrc_private (p_cdio, i_track, CDIO_SUBCHANNEL_TRACK_ISRC );
+char *mmc_get_track_isrc(const CdIo_t *p_cdio, track_t i_track) {
+  if (!p_cdio)
+    return NULL;
+  return mmc_get_mcn_isrc_private(p_cdio, i_track, CDIO_SUBCHANNEL_TRACK_ISRC);
 }
 
 /**
   Read cdtext information for a CdIo_t object .
 
-  @return pointer to data on success, NULL on error or CD-Text information does
-  not exist.
+  @return pointer to data on success, NULL on error or CD-Text information
+  does not exist.
 
   Note: the caller must free the returned memory
 
 */
-uint8_t *
-mmc_read_cdtext (const CdIo_t *p_cdio)
-{
+uint8_t *mmc_read_cdtext(const CdIo_t *p_cdio) {
 
   unsigned char buf[4];
-  unsigned char * wdata;
-  int           i_status;
-  unsigned int  i_cdtext;
+  unsigned char *wdata;
+  int i_status;
+  unsigned int i_cdtext;
 
-  if ( ! p_cdio )
+  if (!p_cdio)
     return NULL;
 
   /* We may need to give CD-Text a little more time to complete. */
@@ -1044,9 +1048,9 @@ mmc_read_cdtext (const CdIo_t *p_cdio)
   }
 
   if (i_cdtext > CDTEXT_LEN_BINARY_MAX + 2)
-      i_cdtext = CDTEXT_LEN_BINARY_MAX + 4;
+    i_cdtext = CDTEXT_LEN_BINARY_MAX + 4;
   else
-      i_cdtext += 2; /* data length does not include the data length field */
+    i_cdtext += 2; /* data length does not include the data length field */
 
   wdata = malloc(i_cdtext); /* is zeroed in mmc_toc_read_cdtext */
 
@@ -1054,8 +1058,8 @@ mmc_read_cdtext (const CdIo_t *p_cdio)
   i_status = mmc_read_toc_cdtext(p_cdio, &i_cdtext, wdata, 0);
 
   if (i_status != DRIVER_OP_SUCCESS) {
-      free(wdata);
-      return NULL;
+    free(wdata);
+    return NULL;
   }
 
   return wdata;
@@ -1067,8 +1071,7 @@ mmc_read_cdtext (const CdIo_t *p_cdio)
   @return 1 if media is open, 0 if closed. Error
   return codes are the same as driver_return_code_t
 */
-int mmc_get_tray_status(const CdIo_t *p_cdio)
-{
+int mmc_get_tray_status(const CdIo_t *p_cdio) {
   uint8_t status_buf[2];
   int i_status;
 
@@ -1096,21 +1099,21 @@ int mmc_get_tray_status(const CdIo_t *p_cdio)
    @return number of valid bytes in sense, 0 in case of no sense
    bytes available, <0 in case of internal error.
   */
-int
-mmc_last_cmd_sense(const CdIo_t *p_cdio, cdio_mmc_request_sense_t **pp_sense)
-{
-    generic_img_private_t *gen;
+int mmc_last_cmd_sense(const CdIo_t *p_cdio,
+                       cdio_mmc_request_sense_t **pp_sense) {
+  generic_img_private_t *gen;
 
-    if (!p_cdio) return DRIVER_OP_UNINIT;
-    gen = p_cdio->env;
-    *pp_sense = NULL;
-    if (gen->scsi_mmc_sense_valid <= 0)
-	return 0;
-    *pp_sense = calloc(1, gen->scsi_mmc_sense_valid);
-    if (*pp_sense == NULL)
-        return DRIVER_OP_ERROR;
-    memcpy(*pp_sense, gen->scsi_mmc_sense, gen->scsi_mmc_sense_valid);
-    return gen->scsi_mmc_sense_valid;
+  if (!p_cdio)
+    return DRIVER_OP_UNINIT;
+  gen = p_cdio->env;
+  *pp_sense = NULL;
+  if (gen->scsi_mmc_sense_valid <= 0)
+    return 0;
+  *pp_sense = calloc(1, gen->scsi_mmc_sense_valid);
+  if (*pp_sense == NULL)
+    return DRIVER_OP_ERROR;
+  memcpy(*pp_sense, gen->scsi_mmc_sense, gen->scsi_mmc_sense_valid);
+  return gen->scsi_mmc_sense_valid;
 }
 
 /**
@@ -1127,17 +1130,19 @@ mmc_last_cmd_sense(const CdIo_t *p_cdio, cdio_mmc_request_sense_t **pp_sense)
                        input. We'll figure out what the right CDB length
                        should be.
 */
-driver_return_code_t
-mmc_run_cmd( const CdIo_t *p_cdio, unsigned int i_timeout_ms,
-             const mmc_cdb_t *p_cdb,
-             cdio_mmc_direction_t e_direction, unsigned int i_buf,
-             /*in/out*/ void *p_buf )
-{
-    if (!p_cdio) return DRIVER_OP_UNINIT;
-    if (!p_cdio->op.run_mmc_cmd) return DRIVER_OP_UNSUPPORTED;
-    return p_cdio->op.run_mmc_cmd(p_cdio->env, i_timeout_ms,
-                                  mmc_get_cmd_len(p_cdb->field[0]),
-                                  p_cdb, e_direction, i_buf, p_buf);
+driver_return_code_t mmc_run_cmd(const CdIo_t *p_cdio,
+                                 unsigned int i_timeout_ms,
+                                 const mmc_cdb_t *p_cdb,
+                                 cdio_mmc_direction_t e_direction,
+                                 unsigned int i_buf,
+                                 /*in/out*/ void *p_buf) {
+  if (!p_cdio)
+    return DRIVER_OP_UNINIT;
+  if (!p_cdio->op.run_mmc_cmd)
+    return DRIVER_OP_UNSUPPORTED;
+  return p_cdio->op.run_mmc_cmd(p_cdio->env, i_timeout_ms,
+                                mmc_get_cmd_len(p_cdb->field[0]), p_cdb,
+                                e_direction, i_buf, p_buf);
 }
 
 /* Added by SukkoPera to allow CDB length to be specified manually */
@@ -1161,31 +1166,36 @@ mmc_run_cmd( const CdIo_t *p_cdio, unsigned int i_timeout_ms,
    @return 0 if command completed successfully.
 */
 
-driver_return_code_t
-mmc_run_cmd_len( const CdIo_t *p_cdio, unsigned int i_timeout_ms,
-                  const mmc_cdb_t *p_cdb, unsigned int i_cdb,
-                  cdio_mmc_direction_t e_direction, unsigned int i_buf,
-                  /*in/out*/ void *p_buf )
-{
-  if (!p_cdio) return DRIVER_OP_UNINIT;
-  if (!p_cdio->op.run_mmc_cmd) return DRIVER_OP_UNSUPPORTED;
-  return p_cdio->op.run_mmc_cmd(p_cdio->env, i_timeout_ms,
-                                     i_cdb,
-                                     p_cdb, e_direction, i_buf, p_buf);
+driver_return_code_t mmc_run_cmd_len(const CdIo_t *p_cdio,
+                                     unsigned int i_timeout_ms,
+                                     const mmc_cdb_t *p_cdb, unsigned int i_cdb,
+                                     cdio_mmc_direction_t e_direction,
+                                     unsigned int i_buf,
+                                     /*in/out*/ void *p_buf) {
+  if (!p_cdio)
+    return DRIVER_OP_UNINIT;
+  if (!p_cdio->op.run_mmc_cmd)
+    return DRIVER_OP_UNSUPPORTED;
+  return p_cdio->op.run_mmc_cmd(p_cdio->env, i_timeout_ms, i_cdb, p_cdb,
+                                e_direction, i_buf, p_buf);
 }
 
 /**
   See if CD-ROM has feature with value value
   @return true if we have the feature and false if not.
 */
-bool_3way_t
-mmc_have_interface( CdIo_t *p_cdio, cdio_mmc_feature_interface_t e_interface )
-{
-  int i_status;                  /* Result of MMC command */
-  uint8_t buf[65530] = { 0, };   /* Place to hold returned data */
-  mmc_cdb_t cdb = {{0, }};  /* Command Descriptor Buffer */
+bool_3way_t mmc_have_interface(CdIo_t *p_cdio,
+                               cdio_mmc_feature_interface_t e_interface) {
+  int i_status; /* Result of MMC command */
+  uint8_t buf[65530] = {
+      0,
+  }; /* Place to hold returned data */
+  mmc_cdb_t cdb = {{
+      0,
+  }}; /* Command Descriptor Buffer */
 
-  if (!p_cdio || !p_cdio->op.run_mmc_cmd) return nope;
+  if (!p_cdio || !p_cdio->op.run_mmc_cmd)
+    return nope;
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_GET_CONFIGURATION);
   CDIO_MMC_SET_LEN16(cdb.field, 7, sizeof(buf));
@@ -1193,25 +1203,26 @@ mmc_have_interface( CdIo_t *p_cdio, cdio_mmc_feature_interface_t e_interface )
   cdb.field[1] = CDIO_MMC_GET_CONF_NAMED_FEATURE;
   cdb.field[3] = CDIO_MMC_FEATURE_CORE;
 
-  i_status = mmc_run_cmd(p_cdio, 0, &cdb, SCSI_MMC_DATA_READ, sizeof(buf),
-                         &buf);
+  i_status =
+      mmc_run_cmd(p_cdio, 0, &cdb, SCSI_MMC_DATA_READ, sizeof(buf), &buf);
   if (DRIVER_OP_SUCCESS == i_status) {
     uint8_t *p;
     uint32_t i_data;
     uint8_t *p_max = buf + 65530;
 
-    i_data = (unsigned int) CDIO_MMC_GET_LEN32(buf);
+    i_data = (unsigned int)CDIO_MMC_GET_LEN32(buf);
     /* set to first sense feature code, and then walk through the masks */
     p = buf + 8;
-    while( (p < &(buf[i_data])) && (p < p_max) ) {
+    while ((p < &(buf[i_data])) && (p < p_max)) {
       uint16_t i_feature;
       uint8_t i_feature_additional = p[3];
 
       i_feature = CDIO_MMC_GET_LEN16(p);
       if (CDIO_MMC_FEATURE_CORE == i_feature) {
-        uint8_t *q = p+4;
+        uint8_t *q = p + 4;
         uint32_t i_interface_standard = CDIO_MMC_GET_LEN32(q);
-        if (e_interface == i_interface_standard) return yep;
+        if (e_interface == i_interface_standard)
+          return yep;
       }
       p += i_feature_additional + 4;
     }
@@ -1224,43 +1235,42 @@ mmc_have_interface( CdIo_t *p_cdio, cdio_mmc_feature_interface_t e_interface )
     Read sectors using SCSI-MMC GPCMD_READ_CD.
     Can read only up to 25 blocks.
 */
-driver_return_code_t
-mmc_read_sectors ( const CdIo_t *p_cdio, void *p_buf, lsn_t i_lsn,
-                   int sector_type, uint32_t i_blocks )
-{
-  mmc_cdb_t cdb = {{0, }};
+driver_return_code_t mmc_read_sectors(const CdIo_t *p_cdio, void *p_buf,
+                                      lsn_t i_lsn, int sector_type,
+                                      uint32_t i_blocks) {
+  mmc_cdb_t cdb = {{
+      0,
+  }};
 
   mmc_run_cmd_fn_t run_mmc_cmd;
 
-  if (!p_cdio) return DRIVER_OP_UNINIT;
-  if (!p_cdio->op.run_mmc_cmd ) return DRIVER_OP_UNSUPPORTED;
+  if (!p_cdio)
+    return DRIVER_OP_UNINIT;
+  if (!p_cdio->op.run_mmc_cmd)
+    return DRIVER_OP_UNSUPPORTED;
 
   run_mmc_cmd = p_cdio->op.run_mmc_cmd;
 
   CDIO_MMC_SET_COMMAND(cdb.field, CDIO_MMC_GPCMD_READ_CD);
-  CDIO_MMC_SET_READ_TYPE    (cdb.field, sector_type);
-  CDIO_MMC_SET_READ_LBA     (cdb.field, i_lsn);
+  CDIO_MMC_SET_READ_TYPE(cdb.field, sector_type);
+  CDIO_MMC_SET_READ_LBA(cdb.field, i_lsn);
   CDIO_MMC_SET_READ_LENGTH24(cdb.field, i_blocks);
   CDIO_MMC_SET_MAIN_CHANNEL_SELECTION_BITS(cdb.field,
-					   CDIO_MMC_MCSB_ALL_HEADERS);
+                                           CDIO_MMC_MCSB_ALL_HEADERS);
 
-  return run_mmc_cmd (p_cdio->env, mmc_timeout_ms,
-                      mmc_get_cmd_len(cdb.field[0]), &cdb,
-                      SCSI_MMC_DATA_READ,
-                      CDIO_CD_FRAMESIZE_RAW * i_blocks,
-                      p_buf);
+  return run_mmc_cmd(p_cdio->env, mmc_timeout_ms, mmc_get_cmd_len(cdb.field[0]),
+                     &cdb, SCSI_MMC_DATA_READ, CDIO_CD_FRAMESIZE_RAW * i_blocks,
+                     p_buf);
 }
 
-driver_return_code_t
-mmc_set_blocksize ( const CdIo_t *p_cdio, uint16_t i_blocksize)
-{
-  if ( ! p_cdio )  return DRIVER_OP_UNINIT;
-  return
-    mmc_set_blocksize_private (p_cdio->env, p_cdio->op.run_mmc_cmd,
-                               i_blocksize);
+driver_return_code_t mmc_set_blocksize(const CdIo_t *p_cdio,
+                                       uint16_t i_blocksize) {
+  if (!p_cdio)
+    return DRIVER_OP_UNINIT;
+  return mmc_set_blocksize_private(p_cdio->env, p_cdio->op.run_mmc_cmd,
+                                   i_blocksize);
 }
 
-
 /*
  * Local variables:
  *  c-file-style: "gnu"

--- a/lib/driver/mmc/mmc_ll_cmds.c
+++ b/lib/driver/mmc/mmc_ll_cmds.c
@@ -2,7 +2,7 @@
    Wrappers for specific Multimedia Command (MMC) commands e.g., READ
    DISC, START/STOP UNIT.
 
-   Copyright (C) 2010-2012 Rocky Bernstein <rocky@gnu.org>
+   Copyright (C) 2010-2012, 2026 Rocky Bernstein <rocky@gnu.org>
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@
 #endif
 
 #include <cdio/cdio.h>
+#include <cdio/mmc_util.h>
 #include <cdio/mmc_ll_cmds.h>
 #include "cdio_private.h"
 #include "mmc_cmd_helper.h"
@@ -106,6 +107,82 @@ mmc_get_event_status(const CdIo_t *p_cdio, uint8_t out_buf[2])
     }
     return i_status;
 }
+
+/* Helper: issue plain SCSI INQUIRY (CDIO_MMC_GPCMD_INQUIRY), EVPD = 0
+   (standard). Fills buf up to buf_len and returns 0 on success or negative on
+   error.
+*/
+static int mmc_issue_inquiry(CdIo_t *p_cdio, uint8_t *buf, uint16_t buf_len) {
+  int i_status;
+  MMC_CMD_SETUP(CDIO_MMC_GPCMD_GET_CONFIGURATION);
+  CDIO_MMC_SET_LEN16(cdb.field, 2, buf_len);
+  cdb.field[4] = 0x00;
+
+  if (!p_cdio)
+    return -1;
+
+  i_status = mmc_run_cmd(p_cdio, mmc_timeout_ms, &cdb, SCSI_MMC_DATA_READ,
+                         sizeof(buf), &buf);
+  return i_status;
+}
+
+/* Size we request from INQUIRY: large enough to include version descriptors.
+   Note: this should be less than 256 so the number fits in one byte.
+ */
+#define MMC_INQUIRY_ALLOC 252
+
+/**
+   Get the MMC level supported by the device via INQUIRY and the Version field..
+
+   Parse INQUIRY Version and search for version descriptors indicating
+   MMC support. Returns CDIO_INQUIRY_VERSION_* or CDIO_INQUIRY_VERSION_NONE on transport
+   failure.
+*/
+cdio_mmc_inquiry_version_t mmc_get_INQUIRY_version(CdIo_t *p_cdio)
+{
+  /* Largest buffer size we use. */
+  uint8_t buf[MMC_INQUIRY_ALLOC];
+  uint8_t scsi_version;
+  int rc = mmc_issue_inquiry(p_cdio, buf, sizeof(buf));
+  size_t additional_len = (size_t)buf[4];
+  size_t total_len = 5 + additional_len;
+
+  if (rc != 0) {
+    /* transport failure */
+    return CDIO_INQUIRY_VERSION_NONE;
+  }
+
+  /* Basic sanity checks: minimum INQUIRY length is 36 bytes (standard) */
+  if (buf[4] < 31) {
+    /* additional length field too small to contain version descriptors */
+    return CDIO_INQUIRY_VERSION_WEIRD;
+  }
+
+  /* The standard INQUIRY response contains the 'additional length' at byte 4.
+     The total response length is additional_length + 5. We requested a larger
+     buffer already; compute the actual available length from the device's
+     reported additional length to avoid reading past the device-returned
+     data. */
+  if (total_len > sizeof(buf)) {
+    total_len = sizeof(buf);
+  }
+
+  scsi_version = buf[2] & 0x07;
+
+  switch (scsi_version) {
+  case CDIO_INQUIRY_VERSION_1:
+  case CDIO_INQUIRY_VERSION_1a:
+  case CDIO_INQUIRY_VERSION_2:
+  case CDIO_INQUIRY_VERSION_3:
+  case CDIO_INQUIRY_VERSION_45:
+  case CDIO_INQUIRY_VERSION_5:
+    return (cdio_mmc_inquiry_version_t)scsi_version;
+  default:
+    return CDIO_INQUIRY_VERSION_WEIRD;
+  }
+}
+
+
 /**
    Run a SCSI-MMC MODE SELECT (10-byte) command
    and put the results in p_buf.

--- a/src/cd-drive.c
+++ b/src/cd-drive.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011, 2014, 2017 Rocky Bernstein <rocky@gnu.org>
+  Copyright (C) 2011, 2014, 2017, 2026 Rocky Bernstein <rocky@gnu.org>
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
@@ -194,20 +194,27 @@ print_mmc_drive_level(CdIo_t *p_cdio)
 {
   cdio_mmc_level_t mmc_level = mmc_get_drive_mmc_cap(p_cdio);
 
-  printf( "CD-ROM drive supports " );
+  printf( "SCSI INQUIRY command reports that the drive supports " );
 
   switch(mmc_level) {
   case CDIO_MMC_LEVEL_WEIRD:
     printf("some nonstandard or degenerate set of MMC\n");
     break;
   case CDIO_MMC_LEVEL_1:
-    printf("MMC 1\n");
+  case CDIO_MMC_LEVEL_1a:
+    printf("MMC-1 (CD)\n");
     break;
   case CDIO_MMC_LEVEL_2:
-    printf("MMC 2\n");
+    printf("MMC-2 (DVD)\n");
     break;
   case CDIO_MMC_LEVEL_3:
-    printf("MMC 3\n");
+    printf("SPC-3 / MMC-3 to MMC-5\n");
+    break;
+  case CDIO_MMC_LEVEL_45:
+    printf("SPC-4 / MMC-5\n");
+    break;
+  case CDIO_MMC_LEVEL_5:
+    printf("SPC-5 / MMC-5/6 (CD/DVD/BD)");
     break;
   case CDIO_MMC_LEVEL_NONE:
     printf("no MMC\n");

--- a/src/cd-drive.c
+++ b/src/cd-drive.c
@@ -188,35 +188,35 @@ _log_handler (cdio_log_level_t level, const char message[])
   gl_default_cdio_log_handler (level, message);
 }
 
-/*! Prints out SCSI-MMC drive features  */
+/*! Prints out SCSI-MMC INQUIRY Version  */
 static void
-print_mmc_drive_level(CdIo_t *p_cdio)
+print_mmc_inquiry_version(CdIo_t *p_cdio)
 {
-  cdio_mmc_level_t mmc_level = mmc_get_drive_mmc_cap(p_cdio);
+  cdio_mmc_inquiry_version_t mmc_level = mmc_get_drive_mmc_cap_from_inquiry_version(p_cdio);
 
   printf( "SCSI INQUIRY command reports that the drive supports " );
 
   switch(mmc_level) {
-  case CDIO_MMC_LEVEL_WEIRD:
+  case CDIO_INQUIRY_VERSION_WEIRD:
     printf("some nonstandard or degenerate set of MMC\n");
     break;
-  case CDIO_MMC_LEVEL_1:
-  case CDIO_MMC_LEVEL_1a:
+  case CDIO_INQUIRY_VERSION_1:
+  case CDIO_INQUIRY_VERSION_1a:
     printf("MMC-1 (CD)\n");
     break;
-  case CDIO_MMC_LEVEL_2:
+  case CDIO_INQUIRY_VERSION_2:
     printf("MMC-2 (DVD)\n");
     break;
-  case CDIO_MMC_LEVEL_3:
+  case CDIO_INQUIRY_VERSION_3:
     printf("SPC-3 / MMC-3 to MMC-5\n");
     break;
-  case CDIO_MMC_LEVEL_45:
+  case CDIO_INQUIRY_VERSION_45:
     printf("SPC-4 / MMC-5\n");
     break;
-  case CDIO_MMC_LEVEL_5:
+  case CDIO_INQUIRY_VERSION_5:
     printf("SPC-5 / MMC-5/6 (CD/DVD/BD)");
     break;
-  case CDIO_MMC_LEVEL_NONE:
+  case CDIO_INQUIRY_VERSION_NONE:
     printf("no MMC\n");
     break;
   }
@@ -305,7 +305,7 @@ main(int argc, char *argv[])
 	cdio_hwinfo_t          hwinfo;
 
 	p_cdio = cdio_open(*ppsz_cd, driver_id);
-	print_mmc_drive_level(p_cdio);
+	print_mmc_inquiry_version(p_cdio);
 
 	printf("%28s: %s\n", "Drive", *ppsz_cd);
 
@@ -340,7 +340,7 @@ main(int argc, char *argv[])
 
     if (p_cdio) {
 
-      print_mmc_drive_level(p_cdio);
+      print_mmc_inquiry_version(p_cdio);
 
       if (cdio_get_hwinfo(p_cdio, &hwinfo)) {
 	printf("%-28s: %s\n%-28s: %s\n%-28s: %s\n",

--- a/src/cd-drive.c
+++ b/src/cd-drive.c
@@ -192,7 +192,7 @@ _log_handler (cdio_log_level_t level, const char message[])
 static void
 print_mmc_inquiry_version(CdIo_t *p_cdio)
 {
-  cdio_mmc_inquiry_version_t mmc_level = mmc_get_drive_mmc_cap_from_inquiry_version(p_cdio);
+  cdio_mmc_inquiry_version_t mmc_level = mmc_get_INQUIRY_version(p_cdio);
 
   printf( "SCSI INQUIRY command reports that the drive supports " );
 

--- a/test/driver/mmc_read.c
+++ b/test/driver/mmc_read.c
@@ -168,7 +168,7 @@ print_status_sense(int i_status, int i_sense_valid,
 static void
 print_mmc_inquiry_version(CdIo_t *p_cdio)
 {
-  cdio_mmc_inquiry_version_t mmc_level = mmc_get_drive_mmc_cap_from_inquiry_version(p_cdio);
+  cdio_mmc_inquiry_version_t mmc_level = mmc_get_INQUIRY_version(p_cdio);
 
   printf( "SCSI INQUIRY command reports that the drive supports " );
 

--- a/test/driver/mmc_read.c
+++ b/test/driver/mmc_read.c
@@ -164,6 +164,41 @@ print_status_sense(int i_status, int i_sense_valid,
     printf("\n");
 }
 
+/*! Prints out SCSI-MMC INQUIRY version  */
+static void
+print_mmc_inquiry_version(CdIo_t *p_cdio)
+{
+  cdio_mmc_inquiry_version_t mmc_level = mmc_get_drive_mmc_cap_from_inquiry_version(p_cdio);
+
+  printf( "SCSI INQUIRY command reports that the drive supports " );
+
+  switch(mmc_level) {
+  case CDIO_INQUIRY_VERSION_WEIRD:
+    printf("some nonstandard or degenerate set of MMC\n");
+    break;
+  case CDIO_INQUIRY_VERSION_1:
+  case CDIO_INQUIRY_VERSION_1a:
+    printf("MMC-1 (CD)\n");
+    break;
+  case CDIO_INQUIRY_VERSION_2:
+    printf("MMC-2 (DVD)\n");
+    break;
+  case CDIO_INQUIRY_VERSION_3:
+    printf("SPC-3 / MMC-3 to MMC-5\n");
+    break;
+  case CDIO_INQUIRY_VERSION_45:
+    printf("SPC-4 / MMC-5\n");
+    break;
+  case CDIO_INQUIRY_VERSION_5:
+    printf("SPC-5 / MMC-5/6 (CD/DVD/BD)");
+    break;
+  case CDIO_INQUIRY_VERSION_NONE:
+    printf("no MMC\n");
+    break;
+  }
+  printf("\n");
+}
+
 /* --------------------------- MMC commands ------------------------------ */
 
 
@@ -463,7 +498,10 @@ main(int argc, const char *argv[])
 		/* Test the MMC enhancements of version 0.83 in december 2009 */
 		i_ret = test_read(ppsz_drives[0],
 				  cdio_loglevel_default == CDIO_LOG_DEBUG);
-		if (0 != i_ret) exit(i_ret + 16);
+                if (0 != i_ret)
+                  exit(i_ret + 16);
+
+		print_mmc_inquiry_version(p_cdio);
 	    }
 	} else if (2 == i_ret && b_verbose)
 	    printf("Drive is empty... skipping remaining tests.\n");


### PR DESCRIPTION
Revise mmc-get-drive-cap to use the MMC/SCSCI `INQUIRY` command.

Also clang-format `mmc.c`.

Fixes #70