### PR TITLE
bincue: initialize MODE2 track data layout

### DIFF
--- a/lib/driver/image/bincue.c
+++ b/lib/driver/image/bincue.c
@@ -621,6 +621,9 @@ parse_cuefile (_img_private_t *cd, const char *psz_cue_name)
               this_track->track_format= TRACK_FORMAT_XA;
               this_track->track_green = true;
               this_track->mode        = MODE2_FORM1;
+              this_track->datastart   = 0;
+              this_track->datasize    = CDIO_CD_FRAMESIZE;
+              this_track->endsize     = 0;
               switch(cd->disc_mode) {
               case CDIO_DISC_MODE_NO_INFO:
                 cd->disc_mode = CDIO_DISC_MODE_CD_XA;
@@ -644,6 +647,9 @@ parse_cuefile (_img_private_t *cd, const char *psz_cue_name)
               this_track->track_format= TRACK_FORMAT_XA;
               this_track->track_green = true;
               this_track->mode        = MODE2_FORM2;
+              this_track->datastart   = 0;
+              this_track->datasize    = M2F2_SECTOR_SIZE;
+              this_track->endsize     = 0;
               switch(cd->disc_mode) {
               case CDIO_DISC_MODE_NO_INFO:
                 cd->disc_mode = CDIO_DISC_MODE_CD_XA;

--- a/test/data/Makefile.am
+++ b/test/data/Makefile.am
@@ -46,6 +46,8 @@ check_DATA = \
 	joliet.iso     \
 	malformed.iso  \
 	malformed2.iso \
+	mode2-2048.cue \
+	mode2-2324.cue \
 	multi_extent_8k.iso \
 	multi_extent_file \
 	p1.bin         \

--- a/test/data/mode2-2048.cue
+++ b/test/data/mode2-2048.cue
@@ -1,0 +1,3 @@
+FILE "cdda.bin" BINARY
+  TRACK 01 MODE2/2048
+    INDEX 01 00:00:00

--- a/test/data/mode2-2324.cue
+++ b/test/data/mode2-2324.cue
@@ -1,0 +1,3 @@
+FILE "cdda.bin" BINARY
+  TRACK 01 MODE2/2324
+    INDEX 01 00:00:00

--- a/test/driver/bincue.c
+++ b/test/driver/bincue.c
@@ -96,38 +96,24 @@ check_file_before_first_track(void)
 }
 
 static int
-check_mode2_seek(const char *mode)
+check_mode2_seek(const char *cue_name, const char *mode)
 {
-  const char *cue_name = "bincue-mode2-seek.cue";
-  FILE *cue;
   CdIo_t *p_cdio;
+  char cue_path[500];
   int result = 1;
 
-  cue = fopen(cue_name, "w");
-  if (!cue) {
-    printf("Can't create %s\n", cue_name);
-    return 1;
-  }
-
-  fprintf(cue, "FILE \"%s/cdda.bin\" BINARY\n"
-          "TRACK 01 %s\n"
-          "INDEX 01 00:00:00\n", DATA_DIR, mode);
-  fclose(cue);
-
-  p_cdio = cdio_open_bincue(cue_name);
+  snprintf(cue_path, sizeof(cue_path), "%s/%s", DATA_DIR, cue_name);
+  p_cdio = cdio_open_bincue(cue_path);
   if (!p_cdio) {
     printf("Can't open %s track image\n", mode);
-    goto out;
+    return 1;
   }
   if (cdio_lseek(p_cdio, 0, SEEK_SET) < 0) {
     printf("Can't seek %s track image\n", mode);
-    cdio_destroy(p_cdio);
-    goto out;
+  } else {
+    result = 0;
   }
   cdio_destroy(p_cdio);
-  result = 0;
-out:
-  remove(cue_name);
   return result;
 }
 
@@ -162,8 +148,8 @@ main(int argc, const char *argv[])
     ret = 1;
   if (check_file_before_first_track())
     ret = 1;
-  if (check_mode2_seek("MODE2/2048")
-      || check_mode2_seek("MODE2/2324"))
+  if (check_mode2_seek("mode2-2048.cue", "MODE2/2048")
+      || check_mode2_seek("mode2-2324.cue", "MODE2/2324"))
     ret = 1;
 
   for (i=0; i<NUM_GOOD_CUES; i++) {

--- a/test/driver/bincue.c
+++ b/test/driver/bincue.c
@@ -95,6 +95,42 @@ check_file_before_first_track(void)
   return 0;
 }
 
+static int
+check_mode2_seek(const char *mode)
+{
+  const char *cue_name = "bincue-mode2-seek.cue";
+  FILE *cue;
+  CdIo_t *p_cdio;
+  int result = 1;
+
+  cue = fopen(cue_name, "w");
+  if (!cue) {
+    printf("Can't create %s\n", cue_name);
+    return 1;
+  }
+
+  fprintf(cue, "FILE \"%s/cdda.bin\" BINARY\n"
+          "TRACK 01 %s\n"
+          "INDEX 01 00:00:00\n", DATA_DIR, mode);
+  fclose(cue);
+
+  p_cdio = cdio_open_bincue(cue_name);
+  if (!p_cdio) {
+    printf("Can't open %s track image\n", mode);
+    goto out;
+  }
+  if (cdio_lseek(p_cdio, 0, SEEK_SET) < 0) {
+    printf("Can't seek %s track image\n", mode);
+    cdio_destroy(p_cdio);
+    goto out;
+  }
+  cdio_destroy(p_cdio);
+  result = 0;
+out:
+  remove(cue_name);
+  return result;
+}
+
 int
 main(int argc, const char *argv[])
 {
@@ -125,6 +161,9 @@ main(int argc, const char *argv[])
   if (check_too_many_tracks())
     ret = 1;
   if (check_file_before_first_track())
+    ret = 1;
+  if (check_mode2_seek("MODE2/2048")
+      || check_mode2_seek("MODE2/2324"))
     ret = 1;
 
   for (i=0; i<NUM_GOOD_CUES; i++) {


### PR DESCRIPTION
`parse_cuefile()` accepts `MODE2/2048` and `MODE2/2324` track declarations but leaves their data-layout fields zeroed. When an application seeks through a crafted CUE image, `cdio_lseek()` reaches `_lseek_bincue()`, which divides the requested offset by the zero `datasize` field and terminates with SIGFPE.

Initialize the data size and zero start/end offsets for both track modes so stream seeks use their declared frame layouts.