### PR TITLE
Bound special Rock Ridge names

### DIFF
--- a/lib/iso9660/rock.c
+++ b/lib/iso9660/rock.c
@@ -252,12 +252,29 @@ repeat:
 	if (truncate)
 	  break;
 	if (rr->u.NM.flags & ISO_ROCK_NM_PARENT) {
-	  i_namelen = sizeof("..");
-	  strncat(psz_name, "..", i_namelen);
+	  if ((strlen(psz_name) + sizeof("..") - 1) >= 254) {
+	    truncate = 1;
+	    break;
+	  }
+	  {
+	    size_t i_name_len = strlen(psz_name);
+	    psz_name[i_name_len] = '.';
+	    psz_name[i_name_len + 1] = '.';
+	    psz_name[i_name_len + 2] = '\0';
+	  }
+	  i_namelen += sizeof("..") - 1;
 	  break;
 	} else if (rr->u.NM.flags & ISO_ROCK_NM_CURRENT) {
-	  i_namelen = sizeof(".");
-	  strncat(psz_name, ".", i_namelen);
+	  if ((strlen(psz_name) + sizeof(".") - 1) >= 254) {
+	    truncate = 1;
+	    break;
+	  }
+	  {
+	    size_t i_name_len = strlen(psz_name);
+	    psz_name[i_name_len] = '.';
+	    psz_name[i_name_len + 1] = '\0';
+	  }
+	  i_namelen += sizeof(".") - 1;
 	  break;
 	}
 

--- a/test/testisorr_ce.c
+++ b/test/testisorr_ce.c
@@ -1,4 +1,5 @@
-/* Check that a Rock Ridge CE continuation cannot exceed its block. */
+/* Check that Rock Ridge CE continuations cannot exceed their blocks or the
+   pathname output buffer. */
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -29,6 +30,17 @@ iso9660_iso_seek_read(const iso9660_t *image, void *buffer, lsn_t start,
   (void) image;
   (void) start;
   memset(buffer, 0, (size_t) blocks * ISO_BLOCKSIZE);
+  {
+    size_t i;
+    uint8_t *p = buffer;
+    for (i = 0; i + 5 <= ISO_BLOCKSIZE; i += 5) {
+      p[i + 0] = 'N';
+      p[i + 1] = 'M';
+      p[i + 2] = 5;
+      p[i + 3] = 1;
+      p[i + 4] = ISO_ROCK_NM_CURRENT;
+    }
+  }
   return ISO_BLOCKSIZE;
 }
 
@@ -56,11 +68,16 @@ main(void)
 {
   uint8_t *record = calloc(1, 62);
   iso9660_stat_t *stat = calloc(1, sizeof(*stat) + 2);
-  char name[256] = "";
+  struct {
+    char name[256];
+    uint8_t canary[256];
+  } *output = calloc(1, sizeof(*output));
   int ret = 1;
 
-  if (!record || !stat)
+  if (!record || !stat || !output)
     goto out;
+
+  memset(output->canary, 0xa5, sizeof(output->canary));
 
   record[0] = 62;
   record[32] = 1;
@@ -73,14 +90,43 @@ main(void)
   put_733(&record[54], ISO_BLOCKSIZE - 1);
   stat->rr.b3_rock = dunno;
 
-  if (get_rock_ridge_filename((iso9660_dir_t *) record, record, name,
+  if (get_rock_ridge_filename((iso9660_dir_t *) record, record, output->name,
                               stat) != 0)
     goto out;
   if (stat->rr.u_su_fields & ISO_ROCK_SUF_CE)
     goto out;
 
+  memset(record, 0, 62);
+  record[0] = 62;
+  record[32] = 1;
+  record[33] = 'A';
+  record[34] = 'C';
+  record[35] = 'E';
+  record[36] = 28;
+  record[37] = 1;
+  put_733(&record[38], 1);
+  put_733(&record[46], 0);
+  put_733(&record[54], ISO_BLOCKSIZE - 8);
+  stat->rr.u_su_fields = 0;
+  stat->rr.b3_rock = dunno;
+  memset(output->name, 0, sizeof(output->name));
+
+  if (get_rock_ridge_filename((iso9660_dir_t *) record, record,
+                              output->name, stat) <= 0)
+    goto out;
+  if (strlen(output->name) > 253)
+    goto out;
+  {
+    size_t i;
+    for (i = 0; i < sizeof(output->canary); i++) {
+      if (output->canary[i] != 0xa5)
+        goto out;
+    }
+  }
+
   ret = 0;
 out:
+  free(output);
   free(stat);
   free(record);
   return ret;


### PR DESCRIPTION
Rock Ridge directory records parsed by _iso9660_dir_to_statbuf() pass a
fixed 256-byte buffer to get_rock_ridge_filename(). CURRENT and PARENT NM
records were appended without applying the existing pathname length limit,
so repeated records in a CE continuation could overwrite the stack buffer.

Apply the same 254-character truncation policy to special NM records and keep
the returned name length consistent with the generated string.

The testisorr_ce regression test supplies a CE continuation containing repeated
CURRENT records and verifies that the output buffer and canary remain intact.