### PR TITLE
Validate NRG DAO chunk sizes

### DIFF
--- a/lib/driver/image/nrg.c
+++ b/lib/driver/image/nrg.c
@@ -40,6 +40,8 @@
 #ifdef HAVE_STDBOOL_H
 # include <stdbool.h>
 #endif
+#include <stddef.h>
+#include <stdint.h>
 
 #include <cdio/bytesex.h>
 #include <cdio/ds.h>
@@ -438,10 +440,37 @@ parse_nrg (_img_private_t *p_env, const char *psz_nrg_name,
 	  _daox_t *_xentries = NULL;
 	  _daoi_t *_ientries = NULL;
 	  _dao_array_common_t *_dao_array_common = NULL;
+	  size_t dao_entry_size;
+	  size_t dao_track_count = p_env->gen.i_tracks;
+	  size_t dao_required;
 	  _dao_common_t *_dao_common = (void *) chunk->data;
-	  int disc_mode = _dao_common->unknown[1];
+	  int disc_mode;
 	  track_format_t track_format;
 	  int i;
+
+	  if (dao_track_count == 0)
+	    dao_track_count = 1;
+	  if (DAOX_ID == opcode) {
+	    dao_entry_size = sizeof(_daox_array_t);
+	    dao_required = offsetof(_daox_t, track_info);
+	  } else {
+	    dao_entry_size = sizeof(_daoi_array_t);
+	    dao_required = offsetof(_daoi_t, track_info);
+	  }
+	  if (dao_track_count > (SIZE_MAX - dao_required) / dao_entry_size)
+	    dao_required = SIZE_MAX;
+	  else
+	    dao_required += dao_track_count * dao_entry_size;
+	  if (UINT32_FROM_BE(chunk->len) < dao_required) {
+	    cdio_log(log_level, "truncated DAO%c chunk: need %lu bytes, got %u",
+		      DAOX_ID == opcode ? 'X' : 'I',
+		      (unsigned long) dao_required,
+		      (unsigned int) UINT32_FROM_BE(chunk->len));
+	    free(footer_buf);
+	    return false;
+	  }
+
+	  disc_mode = _dao_common->unknown[1];
 
 	  /* We include an extra 0 byte so these can be used as C strings.*/
 	  p_env->psz_mcn = calloc(1, CDIO_MCN_SIZE+1);

--- a/test/driver/nrg.c
+++ b/test/driver/nrg.c
@@ -35,6 +35,12 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 
 #include <cdio/cdio.h>
 #include <cdio/logging.h>
@@ -46,6 +52,68 @@
 #endif
 
 #define NUM_FIELDS 2
+
+static void
+put_be32(uint8_t *p, uint32_t value)
+{
+  p[0] = value >> 24;
+  p[1] = value >> 16;
+  p[2] = value >> 8;
+  p[3] = value;
+}
+
+static void
+put_be64(uint8_t *p, uint64_t value)
+{
+  put_be32(p, value >> 32);
+  put_be32(p + 4, value);
+}
+
+static int
+check_truncated_dao(void)
+{
+  uint8_t nrg[20] = {0};
+#ifdef HAVE_MKSTEMP
+  char psz_tmp[] = "libcdio-nrg-XXXXXX";
+  int fd;
+#else
+  char *psz_tmp;
+#endif
+  FILE *fp;
+  int ret = 1;
+
+#ifdef HAVE_MKSTEMP
+  fd = mkstemp(psz_tmp);
+  if (fd < 0)
+    return ret;
+  fp = fdopen(fd, "wb");
+  if (!fp) {
+    close(fd);
+    remove(psz_tmp);
+    return ret;
+  }
+#else
+  psz_tmp = tmpnam(NULL);
+  if (!psz_tmp)
+    return ret;
+  fp = fopen(psz_tmp, "wb");
+  if (!fp)
+    return ret;
+#endif
+
+  put_be32(&nrg[0], 0x44414f49); /* DAOI chunk */
+  put_be32(&nrg[4], 0);          /* empty chunk payload */
+  put_be32(&nrg[8], 0x4e455235); /* NER5 footer */
+  put_be64(&nrg[12], 0);         /* footer starts at file offset 0 */
+  if (fwrite(nrg, 1, sizeof(nrg), fp) == sizeof(nrg)) {
+    fclose(fp);
+    ret = cdio_is_nrg(psz_tmp) ? 1 : 0;
+  } else {
+    fclose(fp);
+  }
+  remove(psz_tmp);
+  return ret;
+}
 
 int
 main(int argc, const char *argv[])
@@ -102,6 +170,11 @@ main(int argc, const char *argv[])
     printf("Accepted NRG image with too many tracks: %s.\n", psz_nrgfile);
     cdio_destroy(p_cdio);
     return(4);
+  }
+
+  if (check_truncated_dao() != 0) {
+    printf("Accepted or failed to reject truncated DAO metadata.\n");
+    return(5);
   }
 
   return 0;


### PR DESCRIPTION
NRG image detection reaches parse_nrg() through cdio_is_nrg(). The DAOI/DAOX
parser validated only the generic chunk envelope before reading the fixed DAO
common header and track entries. A truncated DAO chunk could therefore cause
an out-of-bounds read before the image was rejected.

Validate the common header and all DAO track-entry storage required by the
parsed track count before accessing DAO metadata.

Extend the NRG driver test with a minimal zero-length DAOI chunk and verify
that it is rejected cleanly.