### PR TITLE
Bound Rock Ridge deep-directory traversal

### DIFF
--- a/lib/iso9660/iso9660_fs.c
+++ b/lib/iso9660/iso9660_fs.c
@@ -1716,10 +1716,37 @@ iso9660_dirlist_new(void) {
   return (CdioISO9660FileList_t *) _cdio_list_new ();
 }
 
+static int
+find_lsn_visited_cmp (void *p_data, void *p_user_data)
+{
+  return *(lsn_t *)p_data == *(lsn_t *)p_user_data;
+}
+
+/* Return 1 when the LSN was added, 0 when it was already present, and -1
+   when the entry could not be allocated. */
+static int
+find_lsn_mark_visited (CdioList_t *visited, lsn_t lsn)
+{
+  CdioListNode_t *node;
+  lsn_t *p_lsn;
+
+  node = _cdio_list_find (visited, find_lsn_visited_cmp, &lsn);
+  if (node != NULL)
+    return 0;
+
+  p_lsn = malloc (sizeof (*p_lsn));
+  if (p_lsn == NULL)
+    return -1;
+  *p_lsn = lsn;
+  _cdio_list_append (visited, p_lsn);
+  return 1;
+}
+
 static iso9660_stat_t *
 find_lsn_recurse (void *p_image, iso9660_readdir_t iso9660_readdir,
 		  const char psz_path[], lsn_t lsn,
-		  /*out*/ char **ppsz_full_filename)
+		  /*out*/ char **ppsz_full_filename,
+		  CdioList_t *visited)
 {
   CdioISO9660FileList_t *entlist = iso9660_readdir (p_image, psz_path);
   CdioISO9660DirList_t *dirlist = iso9660_filelist_new();
@@ -1739,13 +1766,6 @@ find_lsn_recurse (void *p_image, iso9660_readdir_t iso9660_readdir,
       *ppsz_full_filename = calloc(1, len);
       snprintf (*ppsz_full_filename, len, "%s%s/", psz_path, psz_filename);
 
-      if (statbuf->type == _STAT_DIR
-          && strcmp ((char *) statbuf->filename, ".")
-          && strcmp ((char *) statbuf->filename, "..")) {
-	snprintf (*ppsz_full_filename, len, "%s%s/", psz_path, psz_filename);
-        _cdio_list_append (dirlist, strdup(*ppsz_full_filename));
-      }
-
       if (statbuf->lsn == lsn) {
 	const unsigned int len2 = sizeof(iso9660_stat_t) +
 				  strlen(statbuf->filename) + 1;
@@ -1764,6 +1784,23 @@ find_lsn_recurse (void *p_image, iso9660_readdir_t iso9660_readdir,
 	return ret_stat;
       }
 
+      if (statbuf->type == _STAT_DIR) {
+	int was_visited = find_lsn_mark_visited (visited, statbuf->lsn);
+	if (was_visited < 0) {
+	  iso9660_filelist_free (entlist);
+	  iso9660_dirlist_free (dirlist);
+	  free (*ppsz_full_filename);
+	  *ppsz_full_filename = NULL;
+	  return NULL;
+	}
+	if (!was_visited
+	    || !strcmp ((char *) statbuf->filename, ".")
+	    || !strcmp ((char *) statbuf->filename, ".."))
+	  continue;
+
+	_cdio_list_append (dirlist, strdup(*ppsz_full_filename));
+      }
+
     }
 
   iso9660_filelist_free (entlist);
@@ -1778,7 +1815,7 @@ find_lsn_recurse (void *p_image, iso9660_readdir_t iso9660_readdir,
       *ppsz_full_filename = NULL;
       ret_stat = find_lsn_recurse (p_image, iso9660_readdir,
 				   psz_path_prefix, lsn,
-				   ppsz_full_filename);
+				   ppsz_full_filename, visited);
 
       if (NULL != ret_stat) {
         iso9660_dirlist_free(dirlist);
@@ -1794,6 +1831,22 @@ find_lsn_recurse (void *p_image, iso9660_readdir_t iso9660_readdir,
   return NULL;
 }
 
+static iso9660_stat_t *
+find_lsn_recurse_top (void *p_image, iso9660_readdir_t iso9660_readdir,
+		      const char psz_path[], lsn_t lsn,
+		      /*out*/ char **ppsz_full_filename)
+{
+  CdioList_t *visited = _cdio_list_new ();
+  iso9660_stat_t *ret;
+
+  if (visited == NULL)
+    return NULL;
+  ret = find_lsn_recurse (p_image, iso9660_readdir, psz_path, lsn,
+			  ppsz_full_filename, visited);
+  _cdio_list_free (visited, true, free);
+  return ret;
+}
+
 /**
    Given a directory pointer, find the filesystem entry that contains
    lsn and return information about it.
@@ -1805,8 +1858,9 @@ iso9660_fs_find_lsn(CdIo_t *p_cdio, lsn_t i_lsn)
 {
   char *psz_full_filename = NULL;
   iso9660_stat_t * p_statbuf;
-  p_statbuf = find_lsn_recurse (p_cdio, (iso9660_readdir_t *) iso9660_fs_readdir,
-				"/", i_lsn, &psz_full_filename);
+  p_statbuf = find_lsn_recurse_top (p_cdio,
+					(iso9660_readdir_t *) iso9660_fs_readdir,
+					"/", i_lsn, &psz_full_filename);
   if (psz_full_filename != NULL)
     free(psz_full_filename);
   return p_statbuf;
@@ -1836,8 +1890,9 @@ iso9660_stat_t *
 iso9660_fs_find_lsn_with_path(CdIo_t *p_cdio, lsn_t i_lsn,
 			      /*out*/ char **ppsz_full_filename)
 {
-  return find_lsn_recurse (p_cdio, (iso9660_readdir_t *) iso9660_fs_readdir,
-			   "/", i_lsn, ppsz_full_filename);
+  return find_lsn_recurse_top (p_cdio,
+				       (iso9660_readdir_t *) iso9660_fs_readdir,
+				       "/", i_lsn, ppsz_full_filename);
 }
 
 /**
@@ -1856,8 +1911,9 @@ iso9660_ifs_find_lsn(iso9660_t *p_iso, lsn_t i_lsn)
 {
   char *psz_full_filename = NULL;
   iso9660_stat_t *ret  =
-    find_lsn_recurse (p_iso, (iso9660_readdir_t *) iso9660_ifs_readdir,
-		      "/", i_lsn, &psz_full_filename);
+    find_lsn_recurse_top (p_iso,
+				  (iso9660_readdir_t *) iso9660_ifs_readdir,
+				  "/", i_lsn, &psz_full_filename);
   if (psz_full_filename != NULL)
     free(psz_full_filename);
   return ret;
@@ -1904,7 +1960,8 @@ _iso9660_dd_find_lsn(void* p_image, lsn_t i_lsn)
   /* Disable the deep directory flag so we can process all entries */
   p_header = (cdio_header_t*)p_image_dd;
   p_header->u_flags |= CDIO_HEADER_FLAGS_DISABLE_RR_DD;
-  ret = find_lsn_recurse(p_image_dd, f_readdir, "/", i_lsn, &psz_full_filename);
+  ret = find_lsn_recurse_top(p_image_dd, f_readdir, "/", i_lsn,
+				     &psz_full_filename);
   if (psz_full_filename != NULL)
     free(psz_full_filename);
   free(p_image_dd);
@@ -1932,8 +1989,9 @@ iso9660_stat_t *
 iso9660_ifs_find_lsn_with_path(iso9660_t *p_iso, lsn_t i_lsn,
 			       /*out*/ char **ppsz_full_filename)
 {
-  return find_lsn_recurse (p_iso, (iso9660_readdir_t *) iso9660_ifs_readdir,
-			   "/", i_lsn, ppsz_full_filename);
+  return find_lsn_recurse_top (p_iso,
+				       (iso9660_readdir_t *) iso9660_ifs_readdir,
+				       "/", i_lsn, ppsz_full_filename);
 }
 
 /**

--- a/test/testisorr.c
+++ b/test/testisorr.c
@@ -42,6 +42,9 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -51,6 +54,123 @@
 
 #include <cdio/cdio.h>
 #include <cdio/iso9660.h>
+
+static void
+put_733(uint8_t *p, uint32_t value)
+{
+  p[0] = value;
+  p[1] = value >> 8;
+  p[2] = value >> 16;
+  p[3] = value >> 24;
+  p[4] = value >> 24;
+  p[5] = value >> 16;
+  p[6] = value >> 8;
+  p[7] = value;
+}
+
+static unsigned
+add_cycle_record(uint8_t *dir, unsigned offset, char name, uint32_t extent,
+                 int child_link)
+{
+  const unsigned length = child_link ? 46 : 34;
+  uint8_t *record = dir + offset;
+
+  memset(record, 0, length);
+  record[0] = length;
+  put_733(record + 2, extent);
+  put_733(record + 10, ISO_BLOCKSIZE);
+  record[25] = child_link ? 0 : ISO_DIRECTORY;
+  record[32] = 1;
+  record[33] = name;
+  if (child_link) {
+    record[34] = 'C';
+    record[35] = 'L';
+    record[36] = 12;
+    record[37] = 1;
+    put_733(record + 38, 888);
+  }
+  return offset + length;
+}
+
+static int
+check_rock_ridge_cycle(void)
+{
+  uint8_t pvd[ISO_BLOCKSIZE] = {0};
+  uint8_t dir[ISO_BLOCKSIZE] = {0};
+  unsigned offset = 0;
+  iso9660_t *p_iso = NULL;
+  CdioISO9660FileList_t *entries = NULL;
+  FILE *fp = NULL;
+  int ret = 1;
+#ifdef HAVE_MKSTEMP
+  char psz_tmp[] = "libcdio-rock-cycle-XXXXXX";
+  int fd = mkstemp(psz_tmp);
+  if (fd < 0)
+    return 1;
+  fp = fdopen(fd, "wb");
+#else
+  char *psz_tmp = tmpnam(NULL);
+  if (psz_tmp)
+    fp = fopen(psz_tmp, "wb");
+#endif
+
+  if (!fp)
+    goto out;
+  if (fseek(fp, 21 * ISO_BLOCKSIZE - 1, SEEK_SET) != 0
+      || fputc(0, fp) == EOF)
+    goto out;
+
+  pvd[0] = 1;
+  memcpy(&pvd[1], "CD001", 5);
+  pvd[6] = 1;
+  put_733(&pvd[80], 21);
+  pvd[128] = 0;
+  pvd[129] = 8;
+  pvd[156] = 34;
+  put_733(&pvd[158], 20);
+  put_733(&pvd[166], ISO_BLOCKSIZE);
+  pvd[181] = 2;
+  pvd[188] = 1;
+
+  offset = add_cycle_record(dir, offset, '\0', 20, 0);
+  offset = add_cycle_record(dir, offset, '\1', 20, 0);
+  offset = add_cycle_record(dir, offset, 'A', 20, 0);
+  add_cycle_record(dir, offset, 'X', 999, 1);
+
+  if (fseek(fp, 16 * ISO_BLOCKSIZE, SEEK_SET) != 0
+      || fwrite(pvd, 1, sizeof(pvd), fp) != sizeof(pvd))
+    goto out;
+  memset(pvd, 0, sizeof(pvd));
+  pvd[0] = 255;
+  memcpy(&pvd[1], "CD001", 5);
+  pvd[6] = 1;
+  if (fwrite(pvd, 1, sizeof(pvd), fp) != sizeof(pvd)
+      || fseek(fp, 20 * ISO_BLOCKSIZE, SEEK_SET) != 0
+      || fwrite(dir, 1, sizeof(dir), fp) != sizeof(dir)
+      || fclose(fp) != 0)
+    goto out;
+  fp = NULL;
+
+  p_iso = iso9660_open_ext(psz_tmp, ISO_EXTENSION_ALL);
+  if (!p_iso)
+    goto out;
+  entries = iso9660_ifs_readdir(p_iso, "/");
+  if (!entries)
+    goto out;
+  iso9660_filelist_free(entries);
+  entries = NULL;
+  ret = 0;
+
+out:
+  if (entries)
+    iso9660_filelist_free(entries);
+  if (p_iso)
+    iso9660_close(p_iso);
+  if (fp)
+    fclose(fp);
+  remove(psz_tmp);
+  return ret;
+}
 
 int
 main(int argc, const char *argv[])
@@ -100,6 +220,11 @@ main(int argc, const char *argv[])
   }
 
   iso9660_close(p_iso);
+
+  if (check_rock_ridge_cycle() != 0) {
+    fprintf(stderr, "Rock Ridge deep-directory cycle was not rejected\n");
+    return 4;
+  }
 
   return 0;
 }


### PR DESCRIPTION
Malformed Rock Ridge CL records can cause unbounded recursion during deep-directory lookup. `get_rock_ridge_filename()` follows CL entries through `_iso9660_dd_find_lsn()`, which recursively searches directory extents without tracking visited directories. A directory extent pointing back to itself can therefore exhaust the stack while reading a crafted ISO image.

Track visited directory extents during recursive lookup and skip duplicates. Add a regression test that creates a cyclic Rock Ridge image and reads its root directory.