### PR TITLE
Handle empty UDF file identifiers safely

### DIFF
--- a/lib/udf/udf_fs.c
+++ b/lib/udf/udf_fs.c
@@ -301,8 +301,11 @@ udf_fopen(udf_dirent_t *p_udf_root, const char *psz_name)
 static char*
 unicode16_decode(const uint8_t *data, unsigned int u_len)
 {
-  int i;
+  unsigned int i;
   char* r = NULL;
+
+  if (u_len == 0)
+    return (char *)calloc(1, 1);
 
   switch (data[0])
   {
@@ -310,8 +313,8 @@ unicode16_decode(const uint8_t *data, unsigned int u_len)
     r = (char*)calloc(u_len, 1);
     if (r == NULL)
       return r;
-    for (i=0; i<u_len-1; i++)
-      r[i] = data[i+1];
+    for (i = 1; i < u_len; i++)
+      r[i - 1] = data[i];
     return r;
   case 16:
     cdio_charset_to_utf8((char*)&data[1], u_len-1, &r, "UCS-2BE");

--- a/test/testudf_ad.c
+++ b/test/testudf_ad.c
@@ -17,6 +17,62 @@
 #define DATA_DIR "./data"
 #endif
 
+static void
+set_tag(udf_tag_t *tag, uint16_t id)
+{
+  uint8_t *bytes = (uint8_t *)tag;
+  uint8_t checksum = 0;
+  unsigned int i;
+
+  memset(tag, 0, sizeof(*tag));
+  tag->id = id;
+  for (i = 0; i < 15; i++)
+    if (i != 4)
+      checksum = (uint8_t)(checksum + bytes[i]);
+  tag->cksum = checksum;
+}
+
+static int
+check_zero_length_file_id(udf_t *udf)
+{
+  udf_dirent_t *dirent = calloc(1, sizeof(*dirent));
+  udf_fileid_desc_t *first;
+  udf_fileid_desc_t *target;
+
+  if (!dirent)
+    return 1;
+  dirent->p_udf = udf;
+  dirent->i_loc = 0;
+  dirent->i_loc_end = 0;
+  dirent->dir_left = 80;
+  dirent->sector = calloc(1, UDF_BLOCKSIZE);
+  if (!dirent->sector) {
+    free(dirent);
+    return 1;
+  }
+
+  first = (udf_fileid_desc_t *)(dirent->sector + 1968);
+  set_tag(&first->tag, TAGID_FID);
+  first->i_file_id = 1;
+  first->u.file_id.data[0] = 8;
+
+  target = (udf_fileid_desc_t *)(dirent->sector + 2008);
+  set_tag(&target->tag, TAGID_FID);
+  target->i_file_id = 0;
+  target->icb.loc.lba = 1;
+  target->u.padding.data[0] = 8;
+  dirent->fid = first;
+
+  dirent = udf_readdir(dirent);
+  if (!dirent || !dirent->psz_name || dirent->psz_name[0] != '\0') {
+    if (dirent)
+      udf_dirent_free(dirent);
+    return 1;
+  }
+  udf_dirent_free(dirent);
+  return 0;
+}
+
 int
 main(void)
 {
@@ -40,6 +96,10 @@ main(void)
   udf.stream = cdio_stdio_new(DATA_DIR "/cdda.bin");
   if (!udf.stream)
     goto out;
+
+  if (check_zero_length_file_id(&udf) != 0)
+    goto close;
+  udf.i_position = 0;
 
   test->dirent.p_udf = &udf;
   test->dirent.fe.icb_tag.strat_type = ICBTAG_STRATEGY_TYPE_4;


### PR DESCRIPTION
A malformed UDF File Identifier with length zero reaches `unicode16_decode()` through `udf_readdir()`. The decoder reads a charset byte despite the empty identifier, then its charset-8 loop underflows `u_len - 1` and writes past a zero-byte allocation.

Handle empty identifiers before decoding and use bounds-safe copying for charset-8 names. Add a regression test covering the actual `udf_readdir()` path.