### PR TITLE
Validate UDF File Entry descriptor bounds

### DIFF
--- a/lib/udf/udf_file.c
+++ b/lib/udf/udf_file.c
@@ -117,6 +117,15 @@ offset_to_lba(const udf_dirent_t *p_udf_dirent, off_t i_offset,
     &p_udf_dirent->fe;
   const udf_icbtag_t *p_icb_tag = &p_udf_fe->icb_tag;
   const uint16_t strat_type= uint16_from_le(p_icb_tag->strat_type);
+  const uint32_t i_extended_attr =
+    uint32_from_le(p_udf_fe->u_extended_attr);
+  const uint32_t i_alloc_descs = uint32_from_le(p_udf_fe->u_alloc_descs);
+
+  if (i_extended_attr > UDF_BLOCKSIZE - UDF_FENTRY_SIZE
+      || i_alloc_descs > UDF_BLOCKSIZE - UDF_FENTRY_SIZE - i_extended_attr) {
+    cdio_warn("File entry allocation descriptors out of bounds");
+    return CDIO_INVALID_LBA;
+  }
 
   if (i_offset < 0) {
     cdio_warn("Negative offset value");

--- a/test/testudf_ad.c
+++ b/test/testudf_ad.c
@@ -150,6 +150,18 @@ main(void)
   if (nread != DRIVER_OP_ERROR)
     goto close;
 
+  memset(&test->dirent.fe, 0, sizeof(test->dirent.fe));
+  udf.i_position = 0;
+  test->dirent.fe.icb_tag.strat_type = ICBTAG_STRATEGY_TYPE_4;
+  test->dirent.fe.icb_tag.flags = ICBTAG_FLAG_AD_SHORT;
+  test->dirent.fe.info_len = UDF_BLOCKSIZE;
+  test->dirent.fe.u_extended_attr = UDF_BLOCKSIZE;
+  test->dirent.fe.u_alloc_descs = sizeof(udf_short_ad_t);
+
+  nread = udf_read_block(&test->dirent, buffer, 1);
+  if (nread != DRIVER_OP_ERROR)
+    goto close;
+
   ret = 0;
 close:
   cdio_stdio_destroy(udf.stream);


### PR DESCRIPTION
Malformed UDF File Entries can cause an out-of-bounds read during public file reads. `udf_fopen` stores the decoded File Entry in a directory entry, and `udf_read_block` passes it to `offset_to_lba`. That function selects allocation descriptors and computes `GETICB(u_extended_attr + ad_offset)`, but previously did not verify that the extended attributes and allocation descriptors fit within the File Entry block.

This patch validates both ranges before accessing allocation descriptors and rejects invalid entries before they can produce an out-of-bounds read.