### PR TITLE
Confine image extraction paths

### DIFF
--- a/example/extract.c
+++ b/example/extract.c
@@ -86,6 +86,22 @@ static void log_handler (cdio_log_level_t level, const char *message)
   }
 }
 
+static bool
+path_component_is_safe(const char *psz_name)
+{
+  if (!psz_name || !psz_name[0]
+      || 0 == strcmp(psz_name, ".")
+      || 0 == strcmp(psz_name, "..")
+      || strchr(psz_name, '/')
+      || strchr(psz_name, '\\'))
+    return false;
+#ifdef _WIN32
+  if (strchr(psz_name, ':'))
+    return false;
+#endif
+  return true;
+}
+
 static int udf_extract_files(udf_t *p_udf, udf_dirent_t *p_udf_dirent, const char *psz_path)
 {
   FILE *fd = NULL;
@@ -101,6 +117,10 @@ static int udf_extract_files(udf_t *p_udf, udf_dirent_t *p_udf_dirent, const cha
 
   while (udf_readdir(p_udf_dirent)) {
     psz_basename = udf_get_filename(p_udf_dirent);
+    if (!path_component_is_safe(psz_basename)) {
+      fprintf(stderr, "  Refusing unsafe image filename\n");
+      continue;
+    }
     i_length = 3 + strlen(psz_path) + strlen(psz_basename) + strlen(psz_extract_dir);
     psz_fullpath = (char*)calloc(sizeof(char), i_length);
     if (psz_fullpath == NULL) {
@@ -199,6 +219,10 @@ static int iso_extract_files(iso9660_t* p_iso, const char *psz_path)
       || (strcmp(p_statbuf->filename, "..") == 0) )
       continue;
     iso9660_name_translate_ext(p_statbuf->filename, psz_basename, i_joliet_level);
+    if (!path_component_is_safe(psz_basename)) {
+      fprintf(stderr, "  Refusing unsafe image filename\n");
+      continue;
+    }
     if (p_statbuf->type == _STAT_DIR) {
       _mkdir(psz_fullpath);
       if (iso_extract_files(p_iso, psz_iso_name))

--- a/test/check_iso.sh.in
+++ b/test/check_iso.sh.in
@@ -71,6 +71,32 @@ for fname in malformed malformed2; do
     fi
 done
 
+extract_base=/tmp/iso-path-$$
+extract_dir=$extract_base/out
+bad_iso=$extract_base.iso
+escaped_file=$extract_base/escaped.txt
+payload=$extract_dir.payload
+mkdir "$extract_base"
+cp "${srcdir}/data/copying.iso" "$bad_iso"
+printf '../escaped.txt' > "$payload"
+printf '\060' > "$extract_dir.record-length"
+printf '\016' > "$extract_dir.name-length"
+dd if="$extract_dir.record-length" of="$bad_iso" bs=1 seek=$((23 * 2048 + 68)) conv=notrunc 2>/dev/null
+dd if="$extract_dir.name-length" of="$bad_iso" bs=1 seek=$((23 * 2048 + 68 + 32)) conv=notrunc 2>/dev/null
+dd if="$payload" of="$bad_iso" bs=1 seek=$((23 * 2048 + 68 + 33)) conv=notrunc 2>/dev/null
+cmd="../example/extract $bad_iso $extract_dir"
+$cmd >/dev/null 2>&1
+RC=$?
+if test -e "$escaped_file" ; then
+    echo "$0: extractor wrote outside the ISO destination"
+    RC=1
+fi
+rm -f "$bad_iso" "$payload" "$extract_dir.record-length" "$extract_dir.name-length" "$escaped_file"
+if test -d "$extract_base" ; then
+    rm -fr "$extract_base"
+fi
+check_result $RC 'ISO extraction path test' "$cmd"
+
 
 exit $RC
 

--- a/test/check_udf.sh.in
+++ b/test/check_udf.sh.in
@@ -46,6 +46,30 @@ if test $RC -eq 0 ; then
     rm -fr $extract_dir
 fi
 
+extract_base=/tmp/udf-path-$$
+extract_dir=$extract_base/out
+bad_udf=$extract_base.iso
+escaped_file=$extract_base/escaped.txt
+payload=$extract_dir.payload
+mkdir "$extract_base"
+cp "$abs_top_srcdir/test/data/udf102.iso" "$bad_udf"
+printf '\010../escaped.txt' > "$payload"
+printf '\017' > "$extract_dir.length"
+dd if="$extract_dir.length" of="$bad_udf" bs=1 seek=$((596 * 2048 + 40 + 19)) conv=notrunc 2>/dev/null
+dd if="$payload" of="$bad_udf" bs=1 seek=$((596 * 2048 + 40 + 38)) conv=notrunc 2>/dev/null
+cmd="$extract_program $bad_udf $extract_dir"
+$cmd >/dev/null 2>&1
+RC=$?
+if test -e "$escaped_file" ; then
+    echo "$0: extractor wrote outside the UDF destination"
+    RC=1
+fi
+rm -f "$bad_udf" "$payload" "$extract_dir.length" "$escaped_file"
+if test -d "$extract_base" ; then
+    rm -fr "$extract_base"
+fi
+check_result $RC 'UDF extraction path test' "$cmd"
+
 extract_dir=/tmp/udf-bad-fid-$$
 udf_iso=$abs_top_srcdir/test/data/bad-fid.udf
 cmd="$extract_program $udf_iso $extract_dir"


### PR DESCRIPTION
The example extractor allows ISO and UDF filenames to escape the selected output directory. `udf_extract_files` and `iso_extract_files` obtain names directly from image directory entries, append them to `psz_extract_dir`, and pass the resulting paths to `mkdir` or `fopen`. A filename such as `../escaped.txt` can therefore write outside the extraction root.

This patch validates each image filename as a safe single path component and rejects dot components and path separators before filesystem operations.