### PR TITLE
Reject CDRDAO TOCs without tracks

### DIFF
--- a/lib/driver/image/cdrdao.c
+++ b/lib/driver/image/cdrdao.c
@@ -996,6 +996,11 @@ parse_tocfile (_img_private_t *cd, const char *psz_cue_name)
     }
   }
 
+  if (i_track < 0) {
+    cdio_log(log_level, "%s contains no tracks", psz_cue_name);
+    goto err_exit;
+  }
+
   if (NULL != cd) {
     cd->gen.i_tracks = i_track+1;
     cd->gen.toc_init = true;

--- a/test/driver/cdrdao.c
+++ b/test/driver/cdrdao.c
@@ -50,6 +50,30 @@
 
 #define NUM_GOOD_TOCS 17
 #define NUM_BAD_TOCS 10
+
+static int
+check_no_tracks(void)
+{
+  const char *toc_name = "cdrdao-no-tracks.toc";
+  FILE *toc = fopen(toc_name, "w");
+  CdIo_t *p_cdio;
+
+  if (!toc) {
+    fprintf(stderr, "Unable to create %s\n", toc_name);
+    return 1;
+  }
+  fclose(toc);
+
+  p_cdio = cdio_open_cdrdao(toc_name);
+  remove(toc_name);
+  if (p_cdio) {
+    fprintf(stderr, "Incorrect: %s with no tracks opened.\n", toc_name);
+    cdio_destroy(p_cdio);
+    return 1;
+  }
+  return 0;
+}
+
 int
 main(int argc, const char *argv[])
 {
@@ -91,6 +115,8 @@ main(int argc, const char *argv[])
   char psz_tocfile[500];
   unsigned int verbose = (argc > 1);
 
+  if (check_no_tracks())
+    ret = 1;
 
 #ifdef HAVE_CHDIR
       if (0 == chdir(DATA_DIR))


### PR DESCRIPTION
An empty CDRDAO TOC can crash image opening. `parse_tocfile` starts `i_track` at `-1` and, when no `TRACK` line occurs, records zero tracks. During normal `cdio_open_cdrdao` initialization, `get_disc_last_lsn_cdrdao` sets `i_leadout` to zero and dereferences `tocent[i_leadout - 1]`.

This patch rejects TOCs with no parsed tracks before committing parser state, so malformed image metadata is rejected before leadout calculation.