### PR TITLE
Reject BIN/CUE sheets without tracks

### DIFF
--- a/lib/driver/image/bincue.c
+++ b/lib/driver/image/bincue.c
@@ -904,6 +904,11 @@ parse_cuefile (_img_private_t *cd, const char *psz_cue_name)
     }
   }
 
+  if (i < 0) {
+    cdio_log(log_level, "%s contains no tracks", psz_cue_name);
+    goto err_exit;
+  }
+
   if (NULL != cd) {
     cd->gen.toc_init = true;
   }

--- a/test/driver/bincue.c
+++ b/test/driver/bincue.c
@@ -96,6 +96,30 @@ check_file_before_first_track(void)
 }
 
 static int
+check_no_tracks(void)
+{
+  const char *cue_name = "bincue-no-tracks.cue";
+  FILE *cue = fopen(cue_name, "w");
+  CdIo_t *p_cdio;
+
+  if (!cue) {
+    printf("Can't create %s\n", cue_name);
+    return 1;
+  }
+  fprintf(cue, "FILE \"%s/cdda.bin\" BINARY\n", DATA_DIR);
+  fclose(cue);
+
+  p_cdio = cdio_open_bincue(cue_name);
+  remove(cue_name);
+  if (p_cdio) {
+    printf("Incorrect: %s with no tracks opened.\n", cue_name);
+    cdio_destroy(p_cdio);
+    return 1;
+  }
+  return 0;
+}
+
+static int
 check_mode2_seek(const char *cue_name, const char *mode)
 {
   CdIo_t *p_cdio;
@@ -145,6 +169,8 @@ main(int argc, const char *argv[])
   cdio_loglevel_default = (argc > 1) ? CDIO_LOG_DEBUG : CDIO_LOG_WARN;
 
   if (check_too_many_tracks())
+    ret = 1;
+  if (check_no_tracks())
     ret = 1;
   if (check_file_before_first_track())
     ret = 1;


### PR DESCRIPTION
A BIN/CUE sheet containing a `FILE` directive but no `TRACK` directive can crash image opening. `parse_cuefile` leaves its track index at `-1` and returns success. During `_init_bincue`, leadout setup then indexes `tocent[i_tracks - i_first_track]` with zero tracks.

This patch rejects CUE sheets with no parsed tracks before setting `toc_init`, preventing malformed track metadata from reaching leadout initialization.