### PR TITLE
Reject CDRDAO tracks without a mode

### DIFF
--- a/lib/driver/image/cdrdao.c
+++ b/lib/driver/image/cdrdao.c
@@ -629,7 +629,12 @@ parse_tocfile (_img_private_t *cd, const char *psz_cue_name)
 	    cdio_log(log_level, "'%s' not a valid mode.", psz_field);
 	    goto err_exit;
 	  }
-	}
+	  } else {
+	    cdio_log(log_level, "%s line %d after word TRACK:",
+	             psz_cue_name, i_line);
+	    cdio_log(log_level, "Expecting a track mode, got nothing.");
+	    goto err_exit;
+	  }
 	if (NULL != (psz_field = strtok_r(NULL, " \t\n\r", &saveptr))) {
 	  /* \todo: set sub-channel-mode */
 #ifdef TODO

--- a/test/driver/cdrdao.c
+++ b/test/driver/cdrdao.c
@@ -74,6 +74,30 @@ check_no_tracks(void)
   return 0;
 }
 
+static int
+check_track_without_mode(void)
+{
+  const char *toc_name = "cdrdao-track-without-mode.toc";
+  FILE *toc = fopen(toc_name, "w");
+  CdIo_t *p_cdio;
+
+  if (!toc) {
+    fprintf(stderr, "Unable to create %s\n", toc_name);
+    return 1;
+  }
+  fprintf(toc, "TRACK\nFILE \"%s/cdda.bin\" 00:00:00\n", DATA_DIR);
+  fclose(toc);
+
+  p_cdio = cdio_open_cdrdao(toc_name);
+  remove(toc_name);
+  if (p_cdio) {
+    fprintf(stderr, "Incorrect: %s without a mode opened.\n", toc_name);
+    cdio_destroy(p_cdio);
+    return 1;
+  }
+  return 0;
+}
+
 int
 main(int argc, const char *argv[])
 {
@@ -115,7 +139,7 @@ main(int argc, const char *argv[])
   char psz_tocfile[500];
   unsigned int verbose = (argc > 1);
 
-  if (check_no_tracks())
+  if (check_no_tracks() || check_track_without_mode())
     ret = 1;
 
 #ifdef HAVE_CHDIR


### PR DESCRIPTION
A malformed CDRDAO TOC can terminate image opening with SIGFPE. In `parse_tocfile`, a `TRACK` directive increments `i_track`, but omitting its mode leaves the track’s `blocksize` at zero. Later track-size handling in `check_track_is_blocksize_multiple` evaluates `i_size % i_blocksize`.

This patch rejects `TRACK` directives without a recognized mode immediately, preventing incomplete track metadata from reaching zero-divisor arithmetic.