### PR TITLE
Bound recursive UDF directory traversal

### DIFF
--- a/example/extract.c
+++ b/example/extract.c
@@ -75,7 +75,7 @@
 static const char *psz_extract_dir;
 static uint8_t i_joliet_level = 0;
 
-#define MAX_UDF_DIRECTORY_DEPTH 256
+#define MAX_UDF_DIRECTORY_DEPTH 64
 
 static void log_handler (cdio_log_level_t level, const char *message)
 {

--- a/example/extract.c
+++ b/example/extract.c
@@ -75,6 +75,8 @@
 static const char *psz_extract_dir;
 static uint8_t i_joliet_level = 0;
 
+#define MAX_UDF_DIRECTORY_DEPTH 256
+
 static void log_handler (cdio_log_level_t level, const char *message)
 {
   switch(level) {
@@ -102,7 +104,8 @@ path_component_is_safe(const char *psz_name)
   return true;
 }
 
-static int udf_extract_files(udf_t *p_udf, udf_dirent_t *p_udf_dirent, const char *psz_path)
+static int udf_extract_files(udf_t *p_udf, udf_dirent_t *p_udf_dirent,
+                             const char *psz_path, unsigned int depth)
 {
   FILE *fd = NULL;
   int i_length;
@@ -114,6 +117,11 @@ static int udf_extract_files(udf_t *p_udf, udf_dirent_t *p_udf_dirent, const cha
 
   if ((p_udf_dirent == NULL) || (psz_path == NULL))
     return 1;
+  if (depth >= MAX_UDF_DIRECTORY_DEPTH) {
+    fprintf(stderr, "  Maximum UDF directory depth exceeded\n");
+    udf_dirent_free(p_udf_dirent);
+    return 1;
+  }
 
   while (udf_readdir(p_udf_dirent)) {
     psz_basename = udf_get_filename(p_udf_dirent);
@@ -138,7 +146,7 @@ static int udf_extract_files(udf_t *p_udf, udf_dirent_t *p_udf_dirent, const cha
 	p_udf_dirent2 = udf_opendir(p_udf_dirent);
 	if (p_udf_dirent2 != NULL) {
 	  if (udf_extract_files(p_udf, p_udf_dirent2,
-				&psz_fullpath[strlen(psz_extract_dir)]))
+				&psz_fullpath[strlen(psz_extract_dir)], depth + 1))
 	    goto out;
 	}
       } else if (-1 == rc) {
@@ -316,7 +324,7 @@ int main(int argc, char** argv)
   printf("-- Partition number: %d\n", udf_get_part_number(p_udf));
 
   /* Recursively extract files */
-  r = udf_extract_files(p_udf, p_udf_root, "");
+  r = udf_extract_files(p_udf, p_udf_root, "", 0);
 
   goto out;
 

--- a/src/iso-info.c
+++ b/src/iso-info.c
@@ -365,9 +365,16 @@ print_udf_file_info(const udf_dirent_t *p_udf_dirent,
 }
 
 static void
-list_udf_files(udf_t *p_udf, udf_dirent_t *p_udf_dirent, const char *psz_path)
+list_udf_files(udf_t *p_udf, udf_dirent_t *p_udf_dirent,
+               const char *psz_path, unsigned int depth)
 {
   if (!p_udf_dirent) return;
+
+  if (depth >= 256) {
+    fprintf(stderr, "Maximum UDF directory depth exceeded\n");
+    udf_dirent_free(p_udf_dirent);
+    return;
+  }
 
   if (opts.print_iso9660) {
     printf ("\n/%s:\n", psz_path);
@@ -385,7 +392,7 @@ list_udf_files(udf_t *p_udf, udf_dirent_t *p_udf_dirent, const char *psz_path)
         char *psz_newpath = calloc(1, sizeof(char)*i_newlen);
 
         snprintf(psz_newpath, i_newlen, "%s%s/", psz_path, psz_dirname);
-        list_udf_files(p_udf, p_udf_dirent2, psz_newpath);
+        list_udf_files(p_udf, p_udf_dirent2, psz_newpath, depth + 1);
         free(psz_newpath);
       }
     } else {
@@ -413,7 +420,7 @@ print_udf_fs (void)
       return 1;
     }
 
-    list_udf_files(p_udf, p_udf_root, "");
+    list_udf_files(p_udf, p_udf_root, "", 0);
   }
   udf_close(p_udf);
   return 0;

--- a/src/iso-info.c
+++ b/src/iso-info.c
@@ -76,6 +76,8 @@
 */
 #define CDIO_MAX_DIR_RECURSION 512
 
+#define MAX_UDF_DIRECTORY_DEPTH 64
+
 /* Used by `main' to communicate with `parse_opt'. And global options
  */
 static struct arguments
@@ -370,7 +372,7 @@ list_udf_files(udf_t *p_udf, udf_dirent_t *p_udf_dirent,
 {
   if (!p_udf_dirent) return;
 
-  if (depth >= 256) {
+  if (depth >= MAX_UDF_DIRECTORY_DEPTH) {
     fprintf(stderr, "Maximum UDF directory depth exceeded\n");
     udf_dirent_free(p_udf_dirent);
     return;

--- a/test/check_udf.sh.in
+++ b/test/check_udf.sh.in
@@ -70,6 +70,45 @@ if test -d "$extract_base" ; then
 fi
 check_result $RC 'UDF extraction path test' "$cmd"
 
+cycle_base=/tmp/udf-cycle-$$
+cycle_dir=$cycle_base/out
+cycle_udf=$cycle_base.udf
+cycle_hybrid=$cycle_base.hybrid
+mkdir "$cycle_base"
+cp "$abs_top_srcdir/test/data/udf102.iso" "$cycle_udf"
+printf '\002' > "$cycle_base.characteristics"
+printf '\004' > "$cycle_base.type"
+printf '\144\000\000\000' > "$cycle_base.length"
+printf '\003\000\000\000' > "$cycle_base.position"
+dd if="$cycle_base.characteristics" of="$cycle_udf" bs=1 seek=$((596 * 2048 + 40 + 18)) conv=notrunc 2>/dev/null
+dd if="$cycle_base.type" of="$cycle_udf" bs=1 seek=$((597 * 2048 + 27)) conv=notrunc 2>/dev/null
+dd if="$cycle_base.length" of="$cycle_udf" bs=1 seek=$((597 * 2048 + 56)) conv=notrunc 2>/dev/null
+dd if="$cycle_base.position" of="$cycle_udf" bs=1 seek=$((597 * 2048 + 204)) conv=notrunc 2>/dev/null
+cmd="$extract_program $cycle_udf $cycle_dir"
+$cmd >/dev/null 2>&1
+RC=$?
+if test $RC -eq 0 ; then
+    echo "$0: cyclic UDF extraction was not bounded"
+    RC=1
+else
+    RC=0
+fi
+cp "$cycle_udf" "$cycle_hybrid"
+dd if="$abs_top_srcdir/test/data/copying.iso" of="$cycle_hybrid" bs=2048 skip=16 seek=16 count=1 conv=notrunc 2>/dev/null
+info_output=$cycle_base.info
+"$top_builddir/src/iso-info" --no-header -U "$cycle_hybrid" > "$info_output" 2>&1
+info_rc=$?
+info_lines=`wc -l < "$info_output"`
+if test $info_rc -ne 0 || test $info_lines -gt 300 ; then
+    echo "$0: cyclic UDF listing was not bounded"
+    RC=1
+fi
+rm -f "$cycle_udf" "$cycle_hybrid" "$cycle_base.characteristics" "$cycle_base.type" "$cycle_base.length" "$cycle_base.position" "$info_output"
+if test -d "$cycle_base" ; then
+    rm -fr "$cycle_base"
+fi
+check_result $RC 'bounded UDF extraction test' "$cmd"
+
 extract_dir=/tmp/udf-bad-fid-$$
 udf_iso=$abs_top_srcdir/test/data/bad-fid.udf
 cmd="$extract_program $udf_iso $extract_dir"

--- a/test/check_udf.sh.in
+++ b/test/check_udf.sh.in
@@ -80,7 +80,11 @@ printf '\002' > "$cycle_base.characteristics"
 printf '\004' > "$cycle_base.type"
 printf '\144\000\000\000' > "$cycle_base.length"
 printf '\003\000\000\000' > "$cycle_base.position"
+printf '\002' > "$cycle_base.fid-length"
+printf '\010x' > "$cycle_base.fid-name"
 dd if="$cycle_base.characteristics" of="$cycle_udf" bs=1 seek=$((596 * 2048 + 40 + 18)) conv=notrunc 2>/dev/null
+dd if="$cycle_base.fid-length" of="$cycle_udf" bs=1 seek=$((596 * 2048 + 40 + 19)) conv=notrunc 2>/dev/null
+dd if="$cycle_base.fid-name" of="$cycle_udf" bs=1 seek=$((596 * 2048 + 40 + 38)) conv=notrunc 2>/dev/null
 dd if="$cycle_base.type" of="$cycle_udf" bs=1 seek=$((597 * 2048 + 27)) conv=notrunc 2>/dev/null
 dd if="$cycle_base.length" of="$cycle_udf" bs=1 seek=$((597 * 2048 + 56)) conv=notrunc 2>/dev/null
 dd if="$cycle_base.position" of="$cycle_udf" bs=1 seek=$((597 * 2048 + 204)) conv=notrunc 2>/dev/null
@@ -103,7 +107,7 @@ if test $info_rc -ne 0 || test $info_lines -gt 300 ; then
     echo "$0: cyclic UDF listing was not bounded"
     RC=1
 fi
-rm -f "$cycle_udf" "$cycle_hybrid" "$cycle_base.characteristics" "$cycle_base.type" "$cycle_base.length" "$cycle_base.position" "$info_output"
+rm -f "$cycle_udf" "$cycle_hybrid" "$cycle_base.characteristics" "$cycle_base.type" "$cycle_base.length" "$cycle_base.position" "$cycle_base.fid-length" "$cycle_base.fid-name" "$info_output"
 if test -d "$cycle_base" ; then
     rm -fr "$cycle_base"
 fi


### PR DESCRIPTION
Cyclic UDF directory references can cause unbounded recursion in the distributed tools. `example/extract` follows child directories through `udf_readdir`, `udf_is_dir`, and `udf_opendir` in `udf_extract_files`. `iso-info` follows the same image-controlled references in `list_udf_files`. Neither path limits depth or tracks visited directories.

This patch adds a bounded traversal depth to both consumers and stops before following directories beyond the limit, preventing crafted UDF images from exhausting stack or filesystem resources.